### PR TITLE
Add uninstall script for global pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ chmod +x .git/hooks/pre-commit
 mkdir -p code_review_memory
 cp <root>/code_review_memory/* code_review_memory/
 ```
+
+### Uninstallation
+```bash
+curl -fsSL https://raw.githubusercontent.com/YuvalnNexite/pre_commit_code_review/main/uninstall.sh | bash
+```
+or, from a local clone:
+```bash
+./uninstall.sh
+```
 ## Dependencies
 ### Python linting
 pip install flake8

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# uninstall.sh
+set -euo pipefail
+
+GLOBAL_HOOKS_DIR="$HOME/.git-hooks"
+
+echo "Uninstalling pre-commit code review hook..."
+
+if [ -d "$GLOBAL_HOOKS_DIR" ]; then
+  echo "Removing global hooks directory at $GLOBAL_HOOKS_DIR"
+  rm -rf "$GLOBAL_HOOKS_DIR"
+  echo "Removed $GLOBAL_HOOKS_DIR"
+else
+  echo "No global hooks directory found at $GLOBAL_HOOKS_DIR"
+fi
+
+if git config --global --get core.hooksPath >/dev/null 2>&1; then
+  echo "Unsetting git global hooks path..."
+  git config --global --unset core.hooksPath
+  echo "Unset core.hooksPath"
+else
+  echo "Global git core.hooksPath was not set"
+fi
+
+echo "✅ Uninstallation complete."


### PR DESCRIPTION
## Summary
- add an uninstall script that removes the global hooks directory and unsets the git hooks path
- document how to run the uninstall script next to the installation instructions

## Testing
- ./uninstall.sh

------
https://chatgpt.com/codex/tasks/task_b_68c85c38f70c832b9e4329ca2a793c06