### PR TITLE
Convert code review formatter to Python module with logging

### DIFF
--- a/hooks/code_review_pre-commit.sh
+++ b/hooks/code_review_pre-commit.sh
@@ -213,21 +213,23 @@ PROMPT
   mv -f "$tmp_out" "$out"
   formatter=""
   for candidate in \
+    "${repo_path}/scripts/code_review_formatting.py" \
     "${repo_path}/scripts/post_review_formatting" \
+    "${HOME}/.git-hooks-code-review/scripts/code_review_formatting.py" \
     "${HOME}/.git-hooks-code-review/scripts/post_review_formatting"; do
     if [ -z "$formatter" ] && [ -x "$candidate" ]; then
       formatter="$candidate"
     fi
   done
   if [ -n "$formatter" ]; then
-    log_stage "Async review: running post-review formatter (${formatter})"
+    log_stage "Async review: running code review formatter (${formatter})"
     if "$formatter" "$out" >/dev/null 2>>"$tmp_stderr"; then
       log_stage "Async review: formatter completed successfully"
     else
       log_stage "Async review: formatter encountered an error"
     fi
   else
-    log_stage "Async review: post-review formatter not found"
+    log_stage "Async review: code review formatter not found"
   fi
   log_stage "Async review: review output updated"
   log_stage "Async review worker finished"

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ SOURCE_REPO="YuvalnNexite/pre_commit_code_review"
 RAW_BASE="https://raw.githubusercontent.com/${SOURCE_REPO}/main"
 
 HOOK_NAME="code_review_pre-commit.sh"
-FORMATTER_PATH="scripts/post_review_formatting"
+FORMATTER_PATH="scripts/code_review_formatting.py"
 GLOBAL_HOOKS_DIR="$HOME/.git-hooks-code-review"
 
 echo "Installing pre-commit code review hook globally..."
@@ -32,8 +32,8 @@ echo "Setting up global code review memory files..."
 mkdir -p "$GLOBAL_HOOKS_DIR/code_review_memory"
 curl -fsSL "${RAW_BASE}/code_review_memory/memory_template.txt" -o "$GLOBAL_HOOKS_DIR/code_review_memory/memory_template.txt" 2>/dev/null || true
 
-# Download the post-review formatter helper
-echo "Downloading post-review formatter..."
+# Download the code review formatter helper
+echo "Downloading code review formatter..."
 mkdir -p "$GLOBAL_HOOKS_DIR/scripts"
 curl -fsSL "${RAW_BASE}/${FORMATTER_PATH}" -o "$GLOBAL_HOOKS_DIR/${FORMATTER_PATH}"
 chmod +x "$GLOBAL_HOOKS_DIR/${FORMATTER_PATH}"


### PR DESCRIPTION
## Summary
- rename the post-review formatter script to `code_review_formatting.py` and expose it as a Python module
- add timestamped logging that writes to the shared `code_review_progress.log` file
- update the installer and hook to point at the new script name while keeping backward compatibility

## Testing
- `python3 -m compileall scripts/code_review_formatting.py`


------
https://chatgpt.com/codex/tasks/task_b_68cdd5f379dc832bba44a02315ec5c77