### PR TITLE
Add review viewer with live updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ for macOS/Linux:
 curl https://cursor.com/install -fsS | bash
 ```
 
+
+## Review Viewer
+
+An optional Flask web application is available to inspect `auto_code_review.md` files with live refresh support.
+
+### Requirements
+
+Install Flask (and its dependencies) into your Python environment:
+
+```bash
+pip install flask
+```
+
+No additional packages are required—the server polls the filesystem for changes.
+
+### Running the server
+
+```bash
+python scripts/review_viewer/app.py
+```
+
+By default the viewer listens on `http://0.0.0.0:5000`. You can customise the host/port using the environment variables `REVIEW_VIEWER_HOST` and `REVIEW_VIEWER_PORT` (or `PORT`).
+
+Open `http://localhost:5000/` in your browser and select the repository directory that contains the `auto_code_review.md` you want to inspect. The UI renders the Markdown locally—including `diff` code blocks with inline highlighting—and automatically refreshes whenever the file changes. Live updates are delivered over Server-Sent Events, so the page stays in sync without manual reloads.
+
 ## Memory Usage
 To use the persistent memory feature put a code_review_memory directory in the project root and follow the template to create consept.md memory files.
 The AI will consult the memory file when he finds the name of the file related to the changed text.

--- a/scripts/review_viewer/app.py
+++ b/scripts/review_viewer/app.py
@@ -1,0 +1,196 @@
+"""Lightweight viewer for auto_code_review.md files with live updates."""
+from __future__ import annotations
+
+import json
+import os
+import queue
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+from flask import Flask, Response, abort, jsonify, request
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+STATIC_DIR = Path(__file__).resolve().parent / "static"
+DEFAULT_POLL_INTERVAL = float(os.environ.get("REVIEW_VIEWER_POLL_INTERVAL", "1.0"))
+
+app = Flask(__name__, static_folder=str(STATIC_DIR), static_url_path="/static")
+
+
+@dataclass
+class WatchPayload:
+    """Container describing the state of the review file."""
+
+    type: str
+    exists: bool
+    mtime_ns: Optional[int]
+
+    def as_dict(self) -> Dict[str, Optional[str]]:
+        return {
+            "type": self.type,
+            "exists": self.exists,
+            "mtime": format_timestamp(self.mtime_ns),
+        }
+
+
+class ReviewWatcher:
+    """Monitor a single review file for updates and notify subscribers."""
+
+    def __init__(self, file_path: Path, interval: float = DEFAULT_POLL_INTERVAL) -> None:
+        self._file_path = file_path
+        self._interval = max(interval, 0.25)
+        self._subscribers: set[queue.Queue[WatchPayload]] = set()
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._last_state = self._current_state()
+
+        self._thread = threading.Thread(target=self._run, name=f"watch:{file_path}", daemon=True)
+        self._thread.start()
+
+    def subscribe(self) -> queue.Queue[WatchPayload]:
+        subscriber: queue.Queue[WatchPayload] = queue.Queue()
+        with self._lock:
+            self._subscribers.add(subscriber)
+        subscriber.put(WatchPayload("status", self._last_state is not None, self._last_state))
+        return subscriber
+
+    def unsubscribe(self, subscriber: queue.Queue[WatchPayload]) -> None:
+        with self._lock:
+            self._subscribers.discard(subscriber)
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        self._thread.join(timeout=1.0)
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            state = self._current_state()
+            if state != self._last_state:
+                self._last_state = state
+                self._broadcast(WatchPayload("update", state is not None, state))
+            self._stop_event.wait(self._interval)
+
+    def _broadcast(self, payload: WatchPayload) -> None:
+        with self._lock:
+            subscribers: Iterable[queue.Queue[WatchPayload]] = tuple(self._subscribers)
+        for subscriber in subscribers:
+            subscriber.put(payload)
+
+    def _current_state(self) -> Optional[int]:
+        try:
+            return self._file_path.stat().st_mtime_ns
+        except FileNotFoundError:
+            return None
+
+
+_watchers: Dict[Path, ReviewWatcher] = {}
+_watchers_lock = threading.Lock()
+
+
+def get_watcher(file_path: Path) -> ReviewWatcher:
+    resolved = file_path.resolve()
+    with _watchers_lock:
+        watcher = _watchers.get(resolved)
+        if watcher is None:
+            watcher = ReviewWatcher(resolved)
+            _watchers[resolved] = watcher
+        return watcher
+
+
+def is_within_base(path: Path) -> bool:
+    try:
+        path.relative_to(BASE_DIR)
+    except ValueError:
+        return False
+    return True
+
+
+def resolve_review_file(raw_directory: Optional[str]) -> Path:
+    directory = (BASE_DIR / (raw_directory or ".")).resolve()
+    if not is_within_base(directory):
+        abort(400, description="Directory is outside the project root.")
+    if not directory.is_dir():
+        abort(404, description="Directory not found.")
+    return directory / "auto_code_review.md"
+
+
+def relative_directory(path: Path) -> str:
+    try:
+        rel = path.relative_to(BASE_DIR)
+    except ValueError:
+        return str(path)
+    return str(rel) if str(rel) else "."
+
+
+def format_timestamp(mtime_ns: Optional[int]) -> Optional[str]:
+    if mtime_ns is None:
+        return None
+    seconds = mtime_ns / 1_000_000_000
+    return datetime.fromtimestamp(seconds, tz=timezone.utc).isoformat()
+
+
+@app.route("/")
+def index() -> Response:
+    return app.send_static_file("index.html")
+
+
+@app.get("/api/review")
+def api_review() -> Response:
+    review_file = resolve_review_file(request.args.get("dir"))
+    if not review_file.exists():
+        abort(404, description="auto_code_review.md not found in the selected directory.")
+    content = review_file.read_text(encoding="utf-8", errors="replace")
+    return jsonify(
+        {
+            "directory": relative_directory(review_file.parent),
+            "content": content,
+        }
+    )
+
+
+@app.get("/stream")
+def stream_updates() -> Response:
+    review_file = resolve_review_file(request.args.get("dir"))
+    watcher = get_watcher(review_file)
+    subscriber = watcher.subscribe()
+
+    def generate() -> Iterable[str]:
+        try:
+            while True:
+                try:
+                    payload = subscriber.get(timeout=15)
+                except queue.Empty:
+                    yield ": keep-alive\n\n"
+                    continue
+                yield f"data: {json.dumps(payload.as_dict())}\n\n"
+        finally:
+            watcher.unsubscribe(subscriber)
+
+    response = Response(generate(), mimetype="text/event-stream")
+    response.headers["Cache-Control"] = "no-cache"
+    response.headers["X-Accel-Buffering"] = "no"
+    return response
+
+
+@app.errorhandler(400)
+def handle_bad_request(error):
+    description = getattr(error, "description", "Bad request")
+    if request.path.startswith("/api/"):
+        return jsonify({"error": description}), 400
+    return description, 400
+
+
+@app.errorhandler(404)
+def handle_not_found(error):
+    description = getattr(error, "description", "Not found")
+    if request.path.startswith("/api/"):
+        return jsonify({"error": description}), 404
+    return description, 404
+
+
+if __name__ == "__main__":
+    host = os.environ.get("REVIEW_VIEWER_HOST", "0.0.0.0")
+    port = int(os.environ.get("REVIEW_VIEWER_PORT", os.environ.get("PORT", "5000")))
+    app.run(host=host, port=port, debug=os.environ.get("FLASK_DEBUG") == "1")

--- a/scripts/review_viewer/static/app.js
+++ b/scripts/review_viewer/static/app.js
@@ -1,0 +1,325 @@
+import applyDiffHighlighting from "./diffRenderer.js";
+
+const STATUS_CLASSES = [
+  "status--muted",
+  "status--success",
+  "status--warning",
+  "status--error",
+  "status--loading",
+];
+
+const HTML_ESCAPE = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+function escapeHtml(value) {
+  return String(value).replace(/[&<>"']/g, (char) => HTML_ESCAPE[char] || char);
+}
+
+function sanitizeLanguage(lang) {
+  if (!lang) {
+    return "plain";
+  }
+  return lang
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9+#.-]+/g, "-");
+}
+
+function sanitizeHref(url) {
+  const trimmed = String(url || "").trim();
+  if (/^(https?:|mailto:|\/|#)/i.test(trimmed)) {
+    return trimmed;
+  }
+  return "#";
+}
+
+function renderInline(text) {
+  const codeSnippets = [];
+  let working = String(text).replace(/`([^`]+)`/g, (_, code) => {
+    const index = codeSnippets.length;
+    codeSnippets.push(`<code class="code-inline">${escapeHtml(code)}</code>`);
+    return `@@CODE${index}@@`;
+  });
+
+  working = escapeHtml(working);
+  working = working.replace(/\*\*([^*]+)\*\*/g, (_, value) => `<strong>${value}</strong>`);
+  working = working.replace(/\*([^*]+)\*/g, (_, value) => `<em>${value}</em>`);
+  working = working.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, label, url) => {
+    return `<a href="${sanitizeHref(url)}" target="_blank" rel="noopener">${label}</a>`;
+  });
+
+  codeSnippets.forEach((snippet, index) => {
+    working = working.replace(`@@CODE${index}@@`, snippet);
+  });
+  return working;
+}
+
+function flushParagraph(buffer, output) {
+  if (!buffer.length) {
+    return;
+  }
+  output.push(`<p>${renderInline(buffer.join(" "))}</p>`);
+  buffer.length = 0;
+}
+
+function flushList(listState, output) {
+  if (!listState.type) {
+    return;
+  }
+  output.push(`</${listState.type}>`);
+  listState.type = null;
+}
+
+function flushCode(codeState, output) {
+  if (!codeState.active) {
+    return;
+  }
+  const language = sanitizeLanguage(codeState.lang);
+  const content = escapeHtml(codeState.lines.join("\n"));
+  output.push(`<pre><code class="language-${language}">${content}</code></pre>`);
+  codeState.active = false;
+  codeState.lines = [];
+  codeState.lang = "plain";
+}
+
+function renderMarkdown(source) {
+  if (!source) {
+    return "";
+  }
+
+  const lines = source.replace(/\r\n/g, "\n").split("\n");
+  const output = [];
+  const paragraph = [];
+  const listState = { type: null };
+  const codeState = { active: false, lang: "plain", lines: [] };
+
+  const closeParagraphAndList = () => {
+    flushParagraph(paragraph, output);
+    flushList(listState, output);
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\s+$/, "");
+    const trimmed = line.trim();
+
+    if (codeState.active) {
+      if (trimmed.startsWith("```") && trimmed.length >= 3) {
+        flushCode(codeState, output);
+      } else {
+        codeState.lines.push(rawLine.replace(/\r$/, ""));
+      }
+      continue;
+    }
+
+    if (trimmed.startsWith("```") && trimmed.length >= 3) {
+      closeParagraphAndList();
+      codeState.active = true;
+      codeState.lang = trimmed.slice(3).trim() || "plain";
+      codeState.lines = [];
+      continue;
+    }
+
+    if (!trimmed) {
+      flushParagraph(paragraph, output);
+      flushList(listState, output);
+      continue;
+    }
+
+    const headingMatch = trimmed.match(/^(#{1,6})\s+(.*)$/);
+    if (headingMatch) {
+      closeParagraphAndList();
+      const level = headingMatch[1].length;
+      output.push(`<h${level}>${renderInline(headingMatch[2])}</h${level}>`);
+      continue;
+    }
+
+    if (/^[-*_]{3,}$/.test(trimmed)) {
+      closeParagraphAndList();
+      output.push("<hr />");
+      continue;
+    }
+
+    if (/^\d+\.\s+/.test(trimmed)) {
+      flushParagraph(paragraph, output);
+      if (listState.type !== "ol") {
+        flushList(listState, output);
+        output.push("<ol>");
+        listState.type = "ol";
+      }
+      const item = trimmed.replace(/^\d+\.\s+/, "");
+      output.push(`<li>${renderInline(item)}</li>`);
+      continue;
+    }
+
+    if (/^[*-]\s+/.test(trimmed)) {
+      flushParagraph(paragraph, output);
+      if (listState.type !== "ul") {
+        flushList(listState, output);
+        output.push("<ul>");
+        listState.type = "ul";
+      }
+      const item = trimmed.replace(/^[*-]\s+/, "");
+      output.push(`<li>${renderInline(item)}</li>`);
+      continue;
+    }
+
+    paragraph.push(line);
+  }
+
+  flushCode(codeState, output);
+  flushParagraph(paragraph, output);
+  flushList(listState, output);
+
+  return output.join("\n");
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const form = document.getElementById("directory-form");
+  const input = document.getElementById("directory-input");
+  const content = document.getElementById("content");
+  const statusEl = document.getElementById("status");
+  const liveStatusEl = document.getElementById("last-updated");
+
+  if (!form || !input || !content) {
+    return;
+  }
+
+  let currentDir = ".";
+  let eventSource = null;
+  let lastPayload = null;
+
+  const setStatus = (message, level = "muted") => {
+    if (!statusEl) {
+      return;
+    }
+    STATUS_CLASSES.forEach((cls) => statusEl.classList.remove(cls));
+    if (!message) {
+      statusEl.textContent = "";
+      return;
+    }
+    statusEl.textContent = message;
+    statusEl.classList.add(`status--${level}`);
+  };
+
+  const updateLiveStatus = (payload) => {
+    if (!liveStatusEl) {
+      return;
+    }
+    if (!payload) {
+      liveStatusEl.textContent = "";
+      return;
+    }
+    if (!payload.exists) {
+      liveStatusEl.textContent = "Watching for changes… (file not found)";
+      return;
+    }
+    if (payload.mtime) {
+      const timestamp = new Date(payload.mtime);
+      if (!Number.isNaN(timestamp.valueOf())) {
+        liveStatusEl.textContent = `Live updates ready — last change ${timestamp.toLocaleString()}`;
+        return;
+      }
+    }
+    liveStatusEl.textContent = "Live updates ready.";
+  };
+
+  const showNotFound = (dir) => {
+    content.innerHTML = `<p class="empty">auto_code_review.md not found in <code>${escapeHtml(dir || ".")}</code>.</p>`;
+  };
+
+  const renderContent = (markdown) => {
+    if (!markdown || !markdown.trim()) {
+      content.innerHTML = '<p class="empty">auto_code_review.md is empty.</p>';
+      return;
+    }
+    const html = renderMarkdown(markdown);
+    content.innerHTML = html;
+    applyDiffHighlighting(content);
+  };
+
+  const fetchContent = async (dir, { silent = false } = {}) => {
+    const targetDir = dir || ".";
+    if (!silent) {
+      setStatus(`Loading review for “${targetDir}”…`, "loading");
+    }
+    try {
+      const response = await fetch(`/api/review?dir=${encodeURIComponent(targetDir)}`);
+      if (response.ok) {
+        const data = await response.json();
+        renderContent(data.content);
+        const displayDir = data.directory || targetDir;
+        if (silent) {
+          const refreshedAt = new Date();
+          setStatus(
+            `auto_code_review.md refreshed automatically (${refreshedAt.toLocaleTimeString()}).`,
+            "success",
+          );
+        } else {
+          setStatus(`Loaded review for “${displayDir}”.`, "success");
+        }
+        return;
+      }
+      if (response.status === 404) {
+        showNotFound(targetDir);
+        setStatus(`No auto_code_review.md found in “${targetDir}”.`, "warning");
+        return;
+      }
+      setStatus(`Failed to load review (status ${response.status}).`, "error");
+    } catch (error) {
+      setStatus("Unable to reach the server.", "error");
+    }
+  };
+
+  const connectStream = (dir) => {
+    if (eventSource) {
+      eventSource.close();
+    }
+    const targetDir = dir || ".";
+    lastPayload = null;
+    updateLiveStatus(null);
+    eventSource = new EventSource(`/stream?dir=${encodeURIComponent(targetDir)}`);
+    eventSource.onopen = () => {
+      if (liveStatusEl) {
+        liveStatusEl.textContent = "Live updates connected.";
+      }
+    };
+    eventSource.onmessage = (event) => {
+      if (!event.data) {
+        return;
+      }
+      try {
+        const payload = JSON.parse(event.data);
+        lastPayload = payload;
+        updateLiveStatus(payload);
+        if (payload.type === "update") {
+          fetchContent(currentDir, { silent: true });
+        }
+      } catch (err) {
+        // Ignore malformed payloads
+      }
+    };
+    eventSource.onerror = () => {
+      updateLiveStatus(lastPayload);
+      if (liveStatusEl) {
+        liveStatusEl.textContent = "Reconnecting for live updates…";
+      }
+    };
+  };
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const value = (input.value || "").trim() || ".";
+    currentDir = value;
+    fetchContent(currentDir);
+    connectStream(currentDir);
+  });
+
+  input.value = currentDir;
+  fetchContent(currentDir);
+  connectStream(currentDir);
+});

--- a/scripts/review_viewer/static/diffRenderer.js
+++ b/scripts/review_viewer/static/diffRenderer.js
@@ -1,0 +1,69 @@
+const DEFAULT_CLASSES = {
+  base: "diff-line",
+  added: "added",
+  removed: "removed",
+  hunk: "hunk",
+  context: "context",
+};
+
+function classifyLine(line, classes) {
+  if (!line) {
+    return classes.context;
+  }
+  if (line.startsWith("diff --git")) {
+    return classes.hunk;
+  }
+  if (line.startsWith("index ")) {
+    return classes.hunk;
+  }
+  if (line.startsWith("+++")) {
+    return classes.hunk;
+  }
+  if (line.startsWith("---")) {
+    return classes.hunk;
+  }
+  if (line.startsWith("@@")) {
+    return classes.hunk;
+  }
+  if (line.startsWith("+")) {
+    return classes.added;
+  }
+  if (line.startsWith("-")) {
+    return classes.removed;
+  }
+  return classes.context;
+}
+
+function createLineElement(line, classes) {
+  const element = document.createElement("div");
+  element.classList.add(classes.base);
+  const kind = classifyLine(line, classes);
+  if (kind) {
+    element.classList.add(kind);
+  }
+  const text = line.length ? line : "\u00a0";
+  element.appendChild(document.createTextNode(text));
+  return element;
+}
+
+export function applyDiffHighlighting(root, options = {}) {
+  const classes = { ...DEFAULT_CLASSES, ...options.classes };
+  const scope = root instanceof HTMLElement ? root : document;
+  const blocks = scope.querySelectorAll("pre code.language-diff");
+  blocks.forEach((block) => {
+    if (block.dataset.rendered === "true") {
+      return;
+    }
+    const raw = block.textContent || "";
+    const lines = raw.replace(/\n$/, "").split("\n");
+    const fragment = document.createDocumentFragment();
+    lines.forEach((line) => {
+      fragment.appendChild(createLineElement(line, classes));
+    });
+    block.innerHTML = "";
+    block.dataset.rendered = "true";
+    block.appendChild(fragment);
+  });
+}
+
+export default applyDiffHighlighting;

--- a/scripts/review_viewer/static/index.html
+++ b/scripts/review_viewer/static/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Auto Code Review Viewer</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="app__header">
+        <h1>Auto Code Review Viewer</h1>
+        <p class="app__tagline">
+          Inspect <code>auto_code_review.md</code> files from this repository with live updates.
+        </p>
+      </header>
+      <section class="controls">
+        <form id="directory-form" class="controls__form">
+          <label for="directory-input">Directory</label>
+          <div class="controls__input-group">
+            <input
+              id="directory-input"
+              type="text"
+              name="dir"
+              placeholder="."
+              autocomplete="off"
+              aria-label="Directory containing auto_code_review.md"
+            />
+            <button type="submit">Load</button>
+          </div>
+        </form>
+        <div id="status" class="status" role="status" aria-live="polite"></div>
+        <div id="last-updated" class="status status--muted"></div>
+      </section>
+      <section id="content" class="content">
+        <p class="placeholder">Select a directory to view its <code>auto_code_review.md</code>.</p>
+      </section>
+    </main>
+    <script type="module" src="/static/app.js"></script>
+  </body>
+</html>

--- a/scripts/review_viewer/static/styles.css
+++ b/scripts/review_viewer/static/styles.css
@@ -1,0 +1,242 @@
+:root {
+  color-scheme: light dark;
+  --background: #f6f8fa;
+  --surface: #ffffff;
+  --border: #d0d7de;
+  --text: #24292f;
+  --muted: #57606a;
+  --accent: #0969da;
+  --success: #1a7f37;
+  --warning: #9a6700;
+  --error: #cf222e;
+  --added-bg: #dafbe1;
+  --removed-bg: #ffebe9;
+  --hunk-bg: #f6f8fa;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #0d1117;
+    --surface: #161b22;
+    --border: #30363d;
+    --text: #c9d1d9;
+    --muted: #8b949e;
+    --accent: #58a6ff;
+    --success: #3fb950;
+    --warning: #cca700;
+    --error: #ff7b72;
+    --added-bg: #033a16;
+    --removed-bg: #3d0c10;
+    --hunk-bg: #161b22;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Segoe UI", Roboto, sans-serif;
+  background: var(--background);
+  color: var(--text);
+}
+
+.app {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 3rem;
+}
+
+.app__header {
+  margin-bottom: 1.5rem;
+}
+
+.app__header h1 {
+  margin: 0 0 0.5rem 0;
+  font-size: 2rem;
+}
+
+.app__tagline {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1rem;
+}
+
+.controls {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem 1.5rem;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.04);
+  margin-bottom: 1.5rem;
+}
+
+.controls__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.controls__form label {
+  font-weight: 600;
+}
+
+.controls__input-group {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.controls__input-group input[type="text"] {
+  flex: 1;
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: inherit;
+}
+
+.controls__input-group button {
+  padding: 0.6rem 1.1rem;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+  font-weight: 600;
+  transition: filter 0.15s ease, transform 0.15s ease;
+}
+
+.controls__input-group button:hover {
+  filter: brightness(1.05);
+}
+
+.controls__input-group button:active {
+  transform: scale(0.98);
+}
+
+.status {
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.status--muted {
+  color: var(--muted);
+}
+
+.status--success {
+  color: var(--success);
+}
+
+.status--warning {
+  color: var(--warning);
+}
+
+.status--error {
+  color: var(--error);
+}
+
+.status--loading {
+  color: var(--accent);
+}
+
+.content {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  overflow-x: auto;
+}
+
+.placeholder {
+  color: var(--muted);
+}
+
+.content h1,
+.content h2,
+.content h3,
+.content h4,
+.content h5,
+.content h6 {
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.content p {
+  line-height: 1.6;
+  margin: 0.75rem 0;
+}
+
+.content ul {
+  padding-left: 1.5rem;
+}
+
+.content li {
+  margin: 0.4rem 0;
+}
+
+pre {
+  padding: 1rem;
+  border-radius: 8px;
+  background: #1e1e1e;
+  color: #dcdcdc;
+  overflow: auto;
+}
+
+pre code {
+  display: block;
+  font-family: "Fira Code", "Source Code Pro", Menlo, monospace;
+  line-height: 1.45;
+  font-size: 0.9rem;
+  white-space: pre;
+}
+
+.code-inline {
+  padding: 0.1rem 0.25rem;
+  border-radius: 4px;
+  background: rgba(99, 110, 123, 0.15);
+}
+
+.diff-line {
+  display: block;
+  white-space: pre;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+}
+
+.diff-line.added {
+  background: var(--added-bg);
+  color: var(--success);
+}
+
+.diff-line.removed {
+  background: var(--removed-bg);
+  color: var(--error);
+}
+
+.diff-line.hunk {
+  background: var(--hunk-bg);
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.diff-line.context {
+  color: inherit;
+}
+
+.empty {
+  color: var(--muted);
+  font-style: italic;
+}
+
+@media (max-width: 640px) {
+  .controls__input-group {
+    flex-direction: column;
+  }
+
+  .controls__input-group button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Flask-based review viewer with safe path handling, JSON API, and SSE notifications for `auto_code_review.md`
- build a single-page UI that renders Markdown, highlights diff blocks, and automatically refreshes when the file changes
- document how to run the viewer, its dependencies, and live-refresh behaviour in the README

## Testing
- python -m compileall scripts/review_viewer

------
https://chatgpt.com/codex/tasks/task_b_68ce5c77f21c832bb8d0d41224d93373