### PR TITLE
Add containerized Auto Code Review viewer

### DIFF
--- a/auto-review-viewer/.dockerignore
+++ b/auto-review-viewer/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log*
+.DS_Store
+.git
+.gitignore

--- a/auto-review-viewer/Dockerfile
+++ b/auto-review-viewer/Dockerfile
@@ -1,0 +1,23 @@
+# Auto Code Review Viewer Dockerfile
+FROM node:20-slim
+
+# Install git for future enhancements that may require repository tooling
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+
+ENV NODE_ENV=production \
+    SRC_DIR=/data \
+    FILENAME=auto_code_review.md \
+    PORT=3000
+
+COPY app/package*.json ./
+RUN if [ -f package-lock.json ]; then npm ci --omit=dev; else npm install --omit=dev; fi
+
+COPY app ./
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/auto-review-viewer/README.md
+++ b/auto-review-viewer/README.md
@@ -1,0 +1,85 @@
+# Auto Code Review Viewer
+
+Render `auto_code_review.md` from a mounted directory with a polished, shareable UI. The viewer runs on Node.js + Express, uses markdown-it for Markdown rendering, highlight.js for syntax highlighting (including diff blocks), and Tailwind CSS for styling.
+
+## Features
+
+- 📄 Reads Markdown from a mounted directory (`/data/auto_code_review.md` by default).
+- 🎨 Beautiful typography powered by Tailwind's typography plugin and highlight.js.
+- 🌓 Sticky header with live file path display and dark mode toggle.
+- 🔁 Automatic refresh when the source file changes (polls `GET /mtime`).
+- 💓 Health check endpoint at `GET /healthz` for container monitoring.
+
+## Project structure
+
+```
+auto-review-viewer/
+├─ app/
+│  ├─ server.js
+│  ├─ package.json
+│  └─ templates/
+│     └─ index.html
+├─ Dockerfile
+├─ docker-compose.yml
+└─ README.md
+```
+
+## Configuration
+
+| Variable   | Default                | Description                                   |
+|------------|------------------------|-----------------------------------------------|
+| `SRC_DIR`  | `/data`                | Directory inside the container to read from. |
+| `FILENAME` | `auto_code_review.md`  | File name to render inside `SRC_DIR`.         |
+| `PORT`     | `3000`                 | Port exposed by the Express server.          |
+
+## Local development
+
+```bash
+cd auto-review-viewer/app
+npm install
+SRC_DIR=/path/to/data FILENAME=auto_code_review.md npm start
+```
+
+The app serves the UI at [http://localhost:3000](http://localhost:3000).
+
+## Docker
+
+Build the container:
+
+```bash
+docker build -t auto-review-viewer ./auto-review-viewer
+```
+
+Run it, mounting the folder that contains `auto_code_review.md`:
+
+```bash
+docker run --rm -p 3000:3000 \
+  -e SRC_DIR=/data \
+  -e FILENAME=auto_code_review.md \
+  -v /absolute/path/to/markdown:/data \
+  auto-review-viewer
+```
+
+## Docker Compose
+
+The included compose file makes it easy to bind a local directory:
+
+```bash
+cd auto-review-viewer
+ACR_SOURCE=/absolute/path/to/markdown docker compose up --build
+```
+
+Environment variables:
+
+- `ACR_SOURCE`: directory to mount at `/data` (defaults to `./data`).
+- `ACR_FILENAME`: optional override for the markdown file name.
+
+## Endpoints
+
+- `GET /` – render the Markdown file as rich HTML.
+- `GET /mtime` – return the file's last modified timestamp (`{ mtimeMs, iso }`).
+- `GET /healthz` – simple health check returning `{ status: "ok" }`.
+
+## Future enhancements
+
+The rendering pipeline is centralized in `server.js` so future features (BAD code annotations, diff-specific actions, WebSockets, etc.) can be layered without rewriting the core. The Docker base already includes Git to support git-aware functionality later on.

--- a/auto-review-viewer/app/package.json
+++ b/auto-review-viewer/app/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "auto-review-viewer",
+  "version": "1.0.0",
+  "description": "Auto Code Review markdown viewer",
+  "main": "server.js",
+  "scripts": {
+    "test": "node --check server.js",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.19.2",
+    "markdown-it": "^14.1.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/auto-review-viewer/app/server.js
+++ b/auto-review-viewer/app/server.js
@@ -1,0 +1,110 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const MarkdownIt = require('markdown-it');
+
+const app = express();
+app.disable('x-powered-by');
+
+const SRC_DIR = process.env.SRC_DIR || '/data';
+const FILENAME = process.env.FILENAME || 'auto_code_review.md';
+const PORT = Number(process.env.PORT || 3000);
+
+const targetPath = path.resolve(SRC_DIR, FILENAME);
+const templatePath = path.join(__dirname, 'templates', 'index.html');
+
+const md = new MarkdownIt({
+  html: true,
+  linkify: true,
+  typographer: true
+});
+
+let cachedTemplate = null;
+
+async function loadTemplate() {
+  if (cachedTemplate) {
+    return cachedTemplate;
+  }
+
+  cachedTemplate = await fs.promises.readFile(templatePath, 'utf8');
+  return cachedTemplate;
+}
+
+async function readMarkdownFile() {
+  return fs.promises.readFile(targetPath, 'utf8');
+}
+
+function injectTemplate(template, renderedMarkdown) {
+  return template
+    .replace(/\{\{FILE_NAME\}\}/g, FILENAME)
+    .replace(/\{\{FILE_PATH\}\}/g, targetPath)
+    .replace(/\{\{CONTENT\}\}/g, renderedMarkdown);
+}
+
+app.get('/', async (req, res) => {
+  try {
+    const [template, markdown] = await Promise.all([
+      loadTemplate(),
+      readMarkdownFile()
+    ]);
+    const rendered = md.render(markdown);
+    const html = injectTemplate(template, rendered);
+
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-store, must-revalidate');
+    res.send(html);
+  } catch (error) {
+    const message = error.code === 'ENOENT'
+      ? `Could not find markdown file at ${targetPath}`
+      : 'Failed to render markdown file.';
+    const details = error.message || 'Unknown error';
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-store, must-revalidate');
+    res.status(500).send(`<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Error</title><style>body{font-family:system-ui,sans-serif;padding:2rem;background:#f8f8f8;color:#111}pre{background:#fff;border-radius:0.5rem;padding:1rem;overflow:auto;border:1px solid #e5e5e5}</style></head><body><h1>Auto Code Review Viewer</h1><p>${message}</p><pre>${details}</pre></body></html>`);
+  }
+});
+
+app.get('/mtime', async (req, res) => {
+  try {
+    const stats = await fs.promises.stat(targetPath);
+    res.setHeader('Cache-Control', 'no-store, max-age=0');
+    res.json({
+      file: FILENAME,
+      mtimeMs: stats.mtimeMs,
+      iso: stats.mtime.toISOString()
+    });
+  } catch (error) {
+    const status = error.code === 'ENOENT' ? 404 : 500;
+    res.setHeader('Cache-Control', 'no-store, max-age=0');
+    res.status(status).json({
+      error: error.message,
+      file: FILENAME
+    });
+  }
+});
+
+app.get('/healthz', (req, res) => {
+  res.setHeader('Cache-Control', 'no-store, max-age=0');
+  res.json({ status: 'ok' });
+});
+
+function ensureSourceDirectory() {
+  return fs.promises.access(targetPath, fs.constants.R_OK)
+    .catch((error) => {
+      const message = error.code === 'ENOENT'
+        ? `Markdown file not found at ${targetPath}`
+        : `Cannot read markdown file at ${targetPath}: ${error.message}`;
+      console.warn(message);
+    });
+}
+
+async function start() {
+  await ensureSourceDirectory();
+
+  app.listen(PORT, () => {
+    console.log(`Auto Code Review Viewer listening on port ${PORT}`);
+    console.log(`Rendering markdown from: ${targetPath}`);
+  });
+}
+
+start();

--- a/auto-review-viewer/app/templates/index.html
+++ b/auto-review-viewer/app/templates/index.html
@@ -306,9 +306,6 @@
             }
 
             fragment.appendChild(span);
-            if (!isLastLine) {
-              fragment.appendChild(document.createTextNode('\n'));
-            }
           });
 
           block.textContent = '';

--- a/auto-review-viewer/app/templates/index.html
+++ b/auto-review-viewer/app/templates/index.html
@@ -1,0 +1,214 @@
+<!doctype html>
+<html lang="en" class="h-full">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Auto Code Review Viewer</title>
+    <script>
+      tailwind = {
+        config: {
+          darkMode: 'class',
+          theme: {
+            extend: {
+              colors: {
+                brand: {
+                  50: '#eef2ff',
+                  500: '#4f46e5',
+                  600: '#4338ca'
+                }
+              },
+              boxShadow: {
+                header: '0 10px 25px -20px rgba(15, 23, 42, 0.7)'
+              }
+            }
+          }
+        }
+      };
+    </script>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <link
+      id="hljs-light"
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css"
+      integrity="sha512-f3fUy6oyboTfp9khSdJj0dk8Z6kOKeZBT5Zzm4jcbmUFzmIum10lANphHz2Xee3RG6Nnz33rgxmzkqOovu0QcQ=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+    <link
+      id="hljs-dark"
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"
+      integrity="sha512-Qcj2tjhL1k4UJgSMuY1OJQrY1hi83CrQn+E21c/Q5v4VXtCaw2V4ckQkZOdhZlJq0pWjTB57TUzRAFGa5Nft6g=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+      disabled
+    />
+    <style>
+      body {
+        font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+      }
+      pre code {
+        font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+      }
+      pre {
+        border-radius: 0.75rem;
+      }
+      .prose pre {
+        padding: 1rem;
+      }
+      .prose code {
+        border-radius: 0.375rem;
+      }
+      .prose :where(code):not(:where([class~="not-prose"] *)) {
+        background-color: rgba(15, 23, 42, 0.05);
+        padding: 0.125rem 0.375rem;
+      }
+      html.dark .prose :where(code):not(:where([class~="not-prose"] *)) {
+        background-color: rgba(148, 163, 184, 0.12);
+      }
+      html.dark body {
+        background-color: #0f172a;
+      }
+    </style>
+  </head>
+  <body class="min-h-full bg-slate-100 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+    <div class="flex min-h-screen flex-col">
+      <header class="sticky top-0 z-20 border-b border-slate-200/70 bg-white/80 backdrop-blur dark:border-slate-800/60 dark:bg-slate-950/80">
+        <div class="mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-4 py-3 sm:px-6">
+          <div class="flex-1 text-left text-base font-semibold tracking-tight sm:text-lg">
+            Auto Code Review Viewer
+          </div>
+          <div class="hidden flex-1 overflow-hidden text-center text-xs font-medium text-slate-500 dark:text-slate-400 sm:block sm:text-sm">
+            Viewing <span class="font-semibold text-slate-700 dark:text-slate-200">{{FILE_NAME}}</span> from
+            <span class="truncate text-slate-500 dark:text-slate-400">{{FILE_PATH}}</span>
+          </div>
+          <div class="flex flex-1 justify-end">
+            <button
+              id="theme-toggle"
+              type="button"
+              class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-600 dark:hover:text-white"
+            >
+              <span aria-hidden="true" id="theme-toggle-icon">🌙</span>
+              <span id="theme-toggle-label">Dark mode</span>
+            </button>
+          </div>
+        </div>
+        <div class="block border-t border-slate-200/70 px-4 py-2 text-xs text-slate-500 dark:border-slate-800/60 dark:text-slate-400 sm:hidden">
+          Viewing <span class="font-semibold text-slate-700 dark:text-slate-200">{{FILE_NAME}}</span>
+          <div class="truncate overflow-hidden text-[11px] text-slate-500 dark:text-slate-400">{{FILE_PATH}}</div>
+        </div>
+      </header>
+      <main class="flex-1">
+        <div class="mx-auto w-full max-w-4xl px-4 pb-10 pt-6 sm:px-6">
+          <article class="prose prose-slate max-w-none dark:prose-invert">
+            {{CONTENT}}
+          </article>
+        </div>
+      </main>
+      <footer class="border-t border-slate-200/70 bg-white/70 py-3 text-sm text-slate-500 backdrop-blur dark:border-slate-800/60 dark:bg-slate-950/70 dark:text-slate-400">
+        <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-4 sm:px-6">
+          <span id="status-line" class="text-slate-500 dark:text-slate-400">Watching for changes…</span>
+          <span class="hidden text-xs sm:block">Auto-refresh enabled</span>
+        </div>
+      </footer>
+    </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-b8qFkC4bIZfv5Ih0b07XHkTTwxabycufV7g9cMPed+0YLsFd1oS29Jym+wIpLW6+BFmGoG9PMa2wiuVdbTNjlQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/diff.min.js" integrity="sha512-f9GtPgNj0JfnYuxzsDgVKfd3RewZF8nPULz/0NkGi/Sd35rEJMMHSdOQcgynb43S/G/Sq0yYMpnt/kFBTw+Fxg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script>
+      const themeToggle = document.getElementById('theme-toggle');
+      const statusLine = document.getElementById('status-line');
+      const themeToggleLabel = document.getElementById('theme-toggle-label');
+      const themeToggleIcon = document.getElementById('theme-toggle-icon');
+      const hljsLight = document.getElementById('hljs-light');
+      const hljsDark = document.getElementById('hljs-dark');
+
+      function applyHighlightTheme(mode) {
+        if (!hljsLight || !hljsDark) return;
+        if (mode === 'dark') {
+          hljsLight.disabled = true;
+          hljsDark.disabled = false;
+        } else {
+          hljsLight.disabled = false;
+          hljsDark.disabled = true;
+        }
+      }
+
+      function setTheme(mode) {
+        const root = document.documentElement;
+        if (mode === 'dark') {
+          root.classList.add('dark');
+          themeToggleLabel.textContent = 'Light mode';
+          themeToggleIcon.textContent = '☀️';
+        } else {
+          root.classList.remove('dark');
+          themeToggleLabel.textContent = 'Dark mode';
+          themeToggleIcon.textContent = '🌙';
+        }
+        applyHighlightTheme(mode);
+      }
+
+      function getPreferredTheme() {
+        const stored = window.localStorage.getItem('acr-theme');
+        if (stored === 'dark' || stored === 'light') {
+          return stored;
+        }
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      }
+
+      function toggleTheme() {
+        const root = document.documentElement;
+        const isDark = root.classList.contains('dark');
+        const next = isDark ? 'light' : 'dark';
+        window.localStorage.setItem('acr-theme', next);
+        setTheme(next);
+      }
+
+      setTheme(getPreferredTheme());
+      themeToggle?.addEventListener('click', toggleTheme);
+
+      let lastSeenMtime = null;
+      let polling = true;
+
+      function formatTimestamp(ms) {
+        const date = new Date(ms);
+        return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+      }
+
+      async function pollMtime() {
+        try {
+          const response = await fetch('/mtime', { cache: 'no-store' });
+          if (!response.ok) {
+            throw new Error(`Request failed with status ${response.status}`);
+          }
+          const payload = await response.json();
+          if (typeof payload.mtimeMs === 'number') {
+            if (lastSeenMtime && payload.mtimeMs > lastSeenMtime) {
+              window.location.reload();
+              return;
+            }
+            lastSeenMtime = payload.mtimeMs;
+            if (statusLine) {
+              statusLine.textContent = `Watching… Last updated ${formatTimestamp(payload.mtimeMs)}`;
+              statusLine.classList.remove('text-red-500');
+              statusLine.classList.add('text-slate-500', 'dark:text-slate-400');
+            }
+          }
+          polling = true;
+        } catch (error) {
+          polling = false;
+          if (statusLine) {
+            statusLine.textContent = 'Disconnected. Retrying…';
+            statusLine.classList.remove('text-slate-500', 'dark:text-slate-400');
+            statusLine.classList.add('text-red-500');
+          }
+          console.error('Failed to poll /mtime', error);
+        } finally {
+          setTimeout(pollMtime, polling ? 2000 : 4000);
+        }
+      }
+
+      hljs.highlightAll();
+      pollMtime();
+    </script>
+  </body>
+</html>

--- a/auto-review-viewer/app/templates/index.html
+++ b/auto-review-viewer/app/templates/index.html
@@ -69,6 +69,62 @@
       html.dark body {
         background-color: #0f172a;
       }
+      pre code.language-diff {
+        display: block;
+        padding: 0;
+      }
+      .diff-line {
+        display: block;
+        white-space: pre;
+        margin: 0 -1rem;
+        padding: 0.125rem 1rem;
+        border-radius: 0;
+      }
+      .diff-line:first-child {
+        border-top-left-radius: 0.75rem;
+        border-top-right-radius: 0.75rem;
+      }
+      .diff-line:last-child {
+        border-bottom-left-radius: 0.75rem;
+        border-bottom-right-radius: 0.75rem;
+      }
+      .diff-context {
+        color: inherit;
+      }
+      .diff-meta {
+        background-color: rgba(148, 163, 184, 0.18);
+        color: #334155;
+        font-weight: 500;
+      }
+      .diff-hunk {
+        background-color: rgba(59, 130, 246, 0.14);
+        color: #1d4ed8;
+        font-weight: 600;
+      }
+      .diff-add {
+        background-color: rgba(34, 197, 94, 0.18);
+        color: #166534;
+      }
+      .diff-remove {
+        background-color: rgba(248, 113, 113, 0.18);
+        color: #7f1d1d;
+      }
+      html.dark .diff-meta {
+        background-color: rgba(148, 163, 184, 0.14);
+        color: #cbd5f5;
+      }
+      html.dark .diff-hunk {
+        background-color: rgba(59, 130, 246, 0.24);
+        color: #bfdbfe;
+      }
+      html.dark .diff-add {
+        background-color: rgba(34, 197, 94, 0.22);
+        color: #bbf7d0;
+      }
+      html.dark .diff-remove {
+        background-color: rgba(248, 113, 113, 0.24);
+        color: #fecaca;
+      }
     </style>
   </head>
   <body class="min-h-full bg-slate-100 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
@@ -207,7 +263,71 @@
         }
       }
 
-      hljs.highlightAll();
+      function enhanceDiffBlocks() {
+        const blocks = document.querySelectorAll('pre code.language-diff');
+        blocks.forEach((block) => {
+          if (!block || block.dataset.enhanced === 'true') return;
+          if (block.childElementCount > 0) {
+            block.dataset.enhanced = 'true';
+            return;
+          }
+
+          const raw = block.textContent || '';
+          const lines = raw.split('\n');
+          const fragment = document.createDocumentFragment();
+
+          lines.forEach((line, index) => {
+            const isLastLine = index === lines.length - 1;
+            if (isLastLine && line === '') {
+              return;
+            }
+
+            const span = document.createElement('span');
+            span.textContent = line;
+            span.classList.add('diff-line');
+
+            const startsWith = (prefix) => line.startsWith(prefix);
+
+            if (startsWith('@@')) {
+              span.classList.add('diff-hunk');
+            } else if (startsWith('+') && !startsWith('+++')) {
+              span.classList.add('diff-add');
+            } else if (startsWith('-') && !startsWith('---')) {
+              span.classList.add('diff-remove');
+            } else if (
+              startsWith('diff ') ||
+              startsWith('index ') ||
+              startsWith('---') ||
+              startsWith('+++')
+            ) {
+              span.classList.add('diff-meta');
+            } else {
+              span.classList.add('diff-context');
+            }
+
+            fragment.appendChild(span);
+            if (!isLastLine) {
+              fragment.appendChild(document.createTextNode('\n'));
+            }
+          });
+
+          block.textContent = '';
+          block.appendChild(fragment);
+          block.dataset.enhanced = 'true';
+        });
+      }
+
+      try {
+        if (window.hljs?.highlightAll) {
+          window.hljs.highlightAll();
+        } else {
+          console.warn('Highlight.js not available; using diff fallback styling.');
+        }
+      } catch (error) {
+        console.error('Failed to apply syntax highlighting', error);
+      }
+
+      enhanceDiffBlocks();
       pollMtime();
     </script>
   </body>

--- a/auto-review-viewer/docker-compose.yml
+++ b/auto-review-viewer/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  viewer:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - SRC_DIR=/data
+      - FILENAME=${ACR_FILENAME:-auto_code_review.md}
+    volumes:
+      - ${ACR_SOURCE:-./data}:/data:ro
+    develop:
+      watch:
+        - action: sync
+          path: ./app
+          target: /usr/src/app
+        - action: rebuild
+          path: ./app/package.json
+        - action: rebuild
+          path: ./Dockerfile


### PR DESCRIPTION
## Summary
- build an Express server that renders the mounted auto_code_review.md file, exposes /mtime and /healthz endpoints, and injects markdown output into a reusable template
- style the UI with Tailwind typography, highlight.js theming, sticky header, dark mode toggle, and an auto-refresh loop that reloads when the source file changes
- provide Docker and docker-compose definitions plus project documentation for easy containerized usage and future enhancements

## Testing
- node --check auto-review-viewer/app/server.js
- npm install (fails: npm registry access denied in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68ce66233454832b91f6758962e56327