### PR TITLE
Fix auto refresh and add diff styling fallback

### DIFF
--- a/auto-review-viewer/app/templates/index.html
+++ b/auto-review-viewer/app/templates/index.html
@@ -306,9 +306,6 @@
             }
 
             fragment.appendChild(span);
-            if (!isLastLine) {
-              fragment.appendChild(document.createTextNode('\n'));
-            }
           });
 
           block.textContent = '';

--- a/auto-review-viewer/app/templates/index.html
+++ b/auto-review-viewer/app/templates/index.html
@@ -69,6 +69,62 @@
       html.dark body {
         background-color: #0f172a;
       }
+      pre code.language-diff {
+        display: block;
+        padding: 0;
+      }
+      .diff-line {
+        display: block;
+        white-space: pre;
+        margin: 0 -1rem;
+        padding: 0.125rem 1rem;
+        border-radius: 0;
+      }
+      .diff-line:first-child {
+        border-top-left-radius: 0.75rem;
+        border-top-right-radius: 0.75rem;
+      }
+      .diff-line:last-child {
+        border-bottom-left-radius: 0.75rem;
+        border-bottom-right-radius: 0.75rem;
+      }
+      .diff-context {
+        color: inherit;
+      }
+      .diff-meta {
+        background-color: rgba(148, 163, 184, 0.18);
+        color: #334155;
+        font-weight: 500;
+      }
+      .diff-hunk {
+        background-color: rgba(59, 130, 246, 0.14);
+        color: #1d4ed8;
+        font-weight: 600;
+      }
+      .diff-add {
+        background-color: rgba(34, 197, 94, 0.18);
+        color: #166534;
+      }
+      .diff-remove {
+        background-color: rgba(248, 113, 113, 0.18);
+        color: #7f1d1d;
+      }
+      html.dark .diff-meta {
+        background-color: rgba(148, 163, 184, 0.14);
+        color: #cbd5f5;
+      }
+      html.dark .diff-hunk {
+        background-color: rgba(59, 130, 246, 0.24);
+        color: #bfdbfe;
+      }
+      html.dark .diff-add {
+        background-color: rgba(34, 197, 94, 0.22);
+        color: #bbf7d0;
+      }
+      html.dark .diff-remove {
+        background-color: rgba(248, 113, 113, 0.24);
+        color: #fecaca;
+      }
     </style>
   </head>
   <body class="min-h-full bg-slate-100 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
@@ -207,7 +263,71 @@
         }
       }
 
-      hljs.highlightAll();
+      function enhanceDiffBlocks() {
+        const blocks = document.querySelectorAll('pre code.language-diff');
+        blocks.forEach((block) => {
+          if (!block || block.dataset.enhanced === 'true') return;
+          if (block.childElementCount > 0) {
+            block.dataset.enhanced = 'true';
+            return;
+          }
+
+          const raw = block.textContent || '';
+          const lines = raw.split('\n');
+          const fragment = document.createDocumentFragment();
+
+          lines.forEach((line, index) => {
+            const isLastLine = index === lines.length - 1;
+            if (isLastLine && line === '') {
+              return;
+            }
+
+            const span = document.createElement('span');
+            span.textContent = line;
+            span.classList.add('diff-line');
+
+            const startsWith = (prefix) => line.startsWith(prefix);
+
+            if (startsWith('@@')) {
+              span.classList.add('diff-hunk');
+            } else if (startsWith('+') && !startsWith('+++')) {
+              span.classList.add('diff-add');
+            } else if (startsWith('-') && !startsWith('---')) {
+              span.classList.add('diff-remove');
+            } else if (
+              startsWith('diff ') ||
+              startsWith('index ') ||
+              startsWith('---') ||
+              startsWith('+++')
+            ) {
+              span.classList.add('diff-meta');
+            } else {
+              span.classList.add('diff-context');
+            }
+
+            fragment.appendChild(span);
+            if (!isLastLine) {
+              fragment.appendChild(document.createTextNode('\n'));
+            }
+          });
+
+          block.textContent = '';
+          block.appendChild(fragment);
+          block.dataset.enhanced = 'true';
+        });
+      }
+
+      try {
+        if (window.hljs?.highlightAll) {
+          window.hljs.highlightAll();
+        } else {
+          console.warn('Highlight.js not available; using diff fallback styling.');
+        }
+      } catch (error) {
+        console.error('Failed to apply syntax highlighting', error);
+      }
+
+      enhanceDiffBlocks();
       pollMtime();
     </script>
   </body>


### PR DESCRIPTION
## Summary
- add guarded highlighting logic so auto-refresh continues working even when Highlight.js is unavailable
- provide a client-side diff styling fallback to keep additions, deletions, and metadata colorized without Highlight.js

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_b_68ce6d0d6c60832b8eec4900167f0e8c