### PR TITLE
Enable auto-update when viewer template changes

### DIFF
--- a/auto-review-viewer/README.md
+++ b/auto-review-viewer/README.md
@@ -77,7 +77,7 @@ Environment variables:
 ## Endpoints
 
 - `GET /` – render the Markdown file as rich HTML.
-- `GET /mtime` – return the file's last modified timestamp (`{ mtimeMs, iso }`).
+- `GET /mtime` – return the latest modified timestamp plus markdown/template details (`{ mtimeMs, iso, markdown, template }`).
 - `GET /healthz` – simple health check returning `{ status: "ok" }`.
 
 ## Future enhancements

--- a/auto-review-viewer/app/templates/index.html
+++ b/auto-review-viewer/app/templates/index.html
@@ -429,14 +429,34 @@
             throw new Error(`Request failed with status ${response.status}`);
           }
           const payload = await response.json();
-          if (typeof payload.mtimeMs === 'number') {
-            if (lastSeenMtime && payload.mtimeMs > lastSeenMtime) {
+          const markdownMtime = payload?.markdown?.mtimeMs;
+          const templateMtime = payload?.template?.mtimeMs;
+          const latestMtime = typeof payload.mtimeMs === 'number' ? payload.mtimeMs : null;
+
+          if (typeof latestMtime === 'number') {
+            if (lastSeenMtime && latestMtime > lastSeenMtime) {
               window.location.reload();
               return;
             }
-            lastSeenMtime = payload.mtimeMs;
+
+            lastSeenMtime = latestMtime;
+
             if (statusLine) {
-              statusLine.textContent = `Watching… Last updated ${formatTimestamp(payload.mtimeMs)}`;
+              const details = [];
+
+              if (typeof markdownMtime === 'number') {
+                details.push(`Markdown ${formatTimestamp(markdownMtime)}`);
+              }
+
+              if (typeof templateMtime === 'number') {
+                details.push(`Template ${formatTimestamp(templateMtime)}`);
+              }
+
+              const message = details.length
+                ? `Watching… ${details.join(' · ')}`
+                : `Watching… Last updated ${formatTimestamp(latestMtime)}`;
+
+              statusLine.textContent = message;
               statusLine.classList.remove('text-red-500');
               statusLine.classList.add('text-slate-500', 'dark:text-slate-400');
             }


### PR DESCRIPTION
## Summary
- detect updates to the HTML template and invalidate the cached content when it changes
- expose both markdown and template modified times from the /mtime endpoint and surface them in the UI auto-refresh logic
- document the richer /mtime response structure for future developers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cea810b438832b8867cc9813996045