### PR TITLE
Add action mode workflow to review viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+auto-review-viewer/new.log

--- a/auto-review-viewer/app/logger.js
+++ b/auto-review-viewer/app/logger.js
@@ -1,0 +1,157 @@
+const fs = require('fs');
+const path = require('path');
+
+const LOG_FILE_PATH = path.join(__dirname, '..', 'new.log');
+const MAX_STRING_LENGTH = 2000;
+const LOG_TO_CONSOLE = process.env.LOG_TO_CONSOLE === 'true';
+
+function truncateString(value) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  if (value.length <= MAX_STRING_LENGTH) {
+    return value;
+  }
+  const truncated = value.slice(0, MAX_STRING_LENGTH);
+  const omitted = value.length - MAX_STRING_LENGTH;
+  return `${truncated}\u2026 (truncated ${omitted} characters)`;
+}
+
+function sanitizeForLog(value, seen = new WeakSet()) {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack
+    };
+  }
+
+  if (Buffer.isBuffer(value)) {
+    return `<Buffer length=${value.length}>`;
+  }
+
+  if (typeof value === 'string') {
+    return truncateString(value);
+  }
+
+  if (value === null || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (typeof value === 'undefined') {
+    return undefined;
+  }
+
+  if (typeof value === 'symbol') {
+    return value.toString();
+  }
+
+  if (typeof value === 'function') {
+    return value.name ? `[Function: ${value.name}]` : '[Function]';
+  }
+
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+    seen.add(value);
+    const result = value.map((item) => sanitizeForLog(item, seen));
+    seen.delete(value);
+    return result;
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+    seen.add(value);
+    const result = {};
+    for (const [key, val] of Object.entries(value)) {
+      const sanitized = sanitizeForLog(val, seen);
+      if (sanitized !== undefined) {
+        result[key] = sanitized;
+      }
+    }
+    seen.delete(value);
+    return result;
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (error) {
+    return String(value);
+  }
+}
+
+function writeLog(level, message, metadata) {
+  const timestamp = new Date().toISOString();
+  const textMessage = truncateString(
+    typeof message === 'string' ? message : String(message)
+  );
+  const sanitizedMeta = sanitizeForLog(metadata);
+
+  let line = `[${timestamp}] [${level}] ${textMessage}`;
+  if (sanitizedMeta !== undefined && !(typeof sanitizedMeta === 'object' && Object.keys(sanitizedMeta).length === 0)) {
+    const metaString = typeof sanitizedMeta === 'object'
+      ? JSON.stringify(sanitizedMeta)
+      : String(sanitizedMeta);
+    line += ` ${metaString}`;
+  }
+  line += '\n';
+
+  fs.promises.appendFile(LOG_FILE_PATH, line).catch((error) => {
+    const consoleLine = `[${timestamp}] [ERROR] Failed to write log entry`;
+    console.error(consoleLine, sanitizeForLog(error));
+  });
+
+  if (level === 'ERROR') {
+    const consoleLine = `[${timestamp}] [${level}] ${textMessage}`;
+    if (sanitizedMeta !== undefined) {
+      console.error(consoleLine, sanitizedMeta);
+    } else {
+      console.error(consoleLine);
+    }
+  } else if (level === 'WARN') {
+    const consoleLine = `[${timestamp}] [${level}] ${textMessage}`;
+    if (sanitizedMeta !== undefined) {
+      console.warn(consoleLine, sanitizedMeta);
+    } else {
+      console.warn(consoleLine);
+    }
+  } else if (LOG_TO_CONSOLE) {
+    const consoleLine = `[${timestamp}] [${level}] ${textMessage}`;
+    if (sanitizedMeta !== undefined) {
+      console.log(consoleLine, sanitizedMeta);
+    } else {
+      console.log(consoleLine);
+    }
+  }
+}
+
+function logDebug(message, metadata) {
+  writeLog('DEBUG', message, metadata);
+}
+
+function logInfo(message, metadata) {
+  writeLog('INFO', message, metadata);
+}
+
+function logWarn(message, metadata) {
+  writeLog('WARN', message, metadata);
+}
+
+function logError(message, metadata) {
+  writeLog('ERROR', message, metadata);
+}
+
+module.exports = {
+  logDebug,
+  logInfo,
+  logWarn,
+  logError,
+  logPath: LOG_FILE_PATH
+};

--- a/auto-review-viewer/app/package.json
+++ b/auto-review-viewer/app/package.json
@@ -4,7 +4,7 @@
   "description": "Auto Code Review markdown viewer",
   "main": "server.js",
   "scripts": {
-    "test": "node --check server.js",
+    "test": "node --check server.js && node --test",
     "start": "node server.js"
   },
   "keywords": [],

--- a/auto-review-viewer/app/review-utils.js
+++ b/auto-review-viewer/app/review-utils.js
@@ -1,0 +1,236 @@
+const { spawn } = require('child_process');
+
+function normalizeNewlines(value) {
+  return typeof value === 'string' ? value.replace(/\r\n/g, '\n') : '';
+}
+
+function mapFieldLabel(label) {
+  if (typeof label !== 'string') {
+    return null;
+  }
+  const normalized = label
+    .toLowerCase()
+    .replace(/\(.*?\)/g, '')
+    .trim();
+
+  if (normalized.startsWith('title')) return 'title';
+  if (normalized.startsWith('file')) return 'file';
+  if (normalized.startsWith('function')) return 'function';
+  if (normalized.startsWith('lines')) return 'lines';
+  if (normalized.startsWith('details')) return 'details';
+  if (normalized.startsWith('suggestion')) return 'suggestion';
+  if (normalized.startsWith('reasoning')) return 'reasoning';
+  return null;
+}
+
+function joinFieldLines(lines) {
+  if (!Array.isArray(lines) || lines.length === 0) {
+    return '';
+  }
+  return normalizeNewlines(lines.join('\n')).trim();
+}
+
+function extractSuggestionParts(text) {
+  const normalized = normalizeNewlines(text);
+  if (!normalized) {
+    return { text: '', diff: null };
+  }
+
+  const fenceRegex = /```(?:diff)?\s*([\s\S]*?)```/i;
+  const match = fenceRegex.exec(normalized);
+  if (!match) {
+    return { text: normalized.trim(), diff: null };
+  }
+
+  const diffBody = match[1] ? match[1] : '';
+  const before = normalized.slice(0, match.index).trim();
+  const after = normalized.slice(match.index + match[0].length).trim();
+  const summaryParts = [];
+  if (before) summaryParts.push(before);
+  if (after) summaryParts.push(after);
+
+  return {
+    text: summaryParts.join('\n\n'),
+    diff: normalizeNewlines(diffBody)
+  };
+}
+
+function parseBadAssessments(markdown) {
+  if (typeof markdown !== 'string' || markdown.trim() === '') {
+    return [];
+  }
+
+  const normalized = normalizeNewlines(markdown);
+  const lines = normalized.split('\n');
+  const allAssessments = [];
+
+  let current = null;
+  let currentField = null;
+  let insideFence = false;
+
+  const assessmentHeaderRegex = /^###\s+Assessment of the change:\s*(BAD|GOOD|NEUTRAL)\s*$/i;
+  const fieldRegex = /^\*\*\s*([^*]+?)\s*:\*\*\s*(.*)$/;
+
+  const finalizeCurrent = () => {
+    if (!current) {
+      return;
+    }
+    const snapshot = {
+      verdict: current.verdict,
+      position: current.position,
+      fields: current.fields
+    };
+    allAssessments.push(snapshot);
+    current = null;
+    currentField = null;
+    insideFence = false;
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const headerMatch = !insideFence && assessmentHeaderRegex.exec(trimmed);
+    if (headerMatch) {
+      finalizeCurrent();
+      current = {
+        verdict: headerMatch[1].toUpperCase(),
+        position: allAssessments.length + 1,
+        fields: {}
+      };
+      currentField = null;
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    if (!insideFence && trimmed === '---') {
+      finalizeCurrent();
+      continue;
+    }
+
+    const fieldMatch = !insideFence && fieldRegex.exec(line);
+    if (fieldMatch) {
+      const label = mapFieldLabel(fieldMatch[1]);
+      const initialValue = fieldMatch[2] ? fieldMatch[2].trim() : '';
+      currentField = label;
+      if (label) {
+        current.fields[label] = initialValue ? [initialValue] : [];
+      }
+      continue;
+    }
+
+    if (!currentField) {
+      continue;
+    }
+
+    const fenceCandidate = line.trim();
+    if (fenceCandidate.startsWith('```')) {
+      insideFence = !insideFence;
+    }
+
+    current.fields[currentField].push(line);
+  }
+
+  finalizeCurrent();
+
+  const badAssessments = [];
+
+  for (const assessment of allAssessments) {
+    if (assessment.verdict !== 'BAD') {
+      continue;
+    }
+
+    const title = joinFieldLines(assessment.fields.title);
+    const file = joinFieldLines(assessment.fields.file);
+    const fn = joinFieldLines(assessment.fields.function);
+    const linesChanged = joinFieldLines(assessment.fields.lines);
+    const details = joinFieldLines(assessment.fields.details);
+    const reasoning = joinFieldLines(assessment.fields.reasoning);
+    const suggestionRaw = joinFieldLines(assessment.fields.suggestion);
+    const suggestionParts = extractSuggestionParts(suggestionRaw);
+
+    badAssessments.push({
+      id: badAssessments.length + 1,
+      position: assessment.position,
+      verdict: 'BAD',
+      title,
+      file,
+      function: fn,
+      lines: linesChanged,
+      details,
+      reasoning,
+      suggestion: {
+        text: suggestionParts.text,
+        diff: suggestionParts.diff
+      }
+    });
+  }
+
+  return badAssessments;
+}
+
+function ensureTrailingNewline(text) {
+  if (text.endsWith('\n')) {
+    return text;
+  }
+  return `${text}\n`;
+}
+
+function runGitCommand(args, cwd, diffText) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('git', args, { cwd });
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+      } else {
+        const error = new Error(`git ${args.join(' ')} failed with exit code ${code}`);
+        error.exitCode = code;
+        error.stdout = stdout;
+        error.stderr = stderr;
+        reject(error);
+      }
+    });
+
+    if (typeof diffText === 'string') {
+      child.stdin.write(diffText);
+    }
+    child.stdin.end();
+  });
+}
+
+async function applySuggestionDiff(diffText, repoDir) {
+  if (typeof diffText !== 'string' || diffText.trim() === '') {
+    throw new Error('Suggestion diff is empty.');
+  }
+  if (typeof repoDir !== 'string' || repoDir.trim() === '') {
+    throw new Error('Repository directory is required.');
+  }
+
+  const normalizedDiff = ensureTrailingNewline(normalizeNewlines(diffText));
+
+  await runGitCommand(['apply', '--check', '--whitespace=nowarn'], repoDir, normalizedDiff);
+  const result = await runGitCommand(['apply', '--whitespace=nowarn'], repoDir, normalizedDiff);
+  return result;
+}
+
+module.exports = {
+  parseBadAssessments,
+  applySuggestionDiff
+};
+

--- a/auto-review-viewer/app/server.js
+++ b/auto-review-viewer/app/server.js
@@ -3,15 +3,19 @@ const fs = require('fs');
 const path = require('path');
 const MarkdownIt = require('markdown-it');
 
+const { parseBadAssessments, applySuggestionDiff } = require('./review-utils');
+
 const app = express();
 app.disable('x-powered-by');
+app.use(express.json({ limit: '1mb' }));
 
-const SRC_DIR = process.env.SRC_DIR || '/data';
+const SRC_DIR = path.resolve(process.env.SRC_DIR || '/data');
 const FILENAME = process.env.FILENAME || 'auto_code_review.md';
 const PORT = Number(process.env.PORT || 3000);
 
 const targetPath = path.resolve(SRC_DIR, FILENAME);
 const templatePath = path.join(__dirname, 'templates', 'index.html');
+const REPO_DIR = process.env.REPO_DIR ? path.resolve(process.env.REPO_DIR) : SRC_DIR;
 
 const md = new MarkdownIt({
   html: true,
@@ -64,6 +68,92 @@ app.get('/', async (req, res) => {
   }
 });
 
+app.get('/api/assessments/bad', async (req, res) => {
+  try {
+    const [markdown, stats] = await Promise.all([
+      readMarkdownFile(),
+      fs.promises.stat(targetPath).catch(() => null)
+    ]);
+    const assessments = parseBadAssessments(markdown);
+
+    res.setHeader('Cache-Control', 'no-store, max-age=0');
+    res.json({
+      file: FILENAME,
+      count: assessments.length,
+      updatedAt: stats ? stats.mtimeMs : null,
+      assessments: assessments.map((assessment) => ({
+        id: assessment.id,
+        verdict: assessment.verdict,
+        position: assessment.position,
+        title: assessment.title,
+        file: assessment.file,
+        function: assessment.function,
+        lines: assessment.lines,
+        details: assessment.details,
+        reasoning: assessment.reasoning,
+        suggestion: assessment.suggestion
+      }))
+    });
+  } catch (error) {
+    const status = error.code === 'ENOENT' ? 404 : 500;
+    res.setHeader('Cache-Control', 'no-store, max-age=0');
+    res.status(status).json({
+      error: status === 404 ? 'Review file not found.' : 'Failed to parse review file.',
+      details: error.message
+    });
+  }
+});
+
+app.post('/api/assessments/:id/apply', async (req, res) => {
+  const id = Number.parseInt(req.params.id, 10);
+  if (!Number.isFinite(id)) {
+    res.status(400).json({ error: 'Invalid assessment identifier.' });
+    return;
+  }
+
+  try {
+    const markdown = await readMarkdownFile();
+    const assessments = parseBadAssessments(markdown);
+    const assessment = assessments.find((item) => item.id === id);
+
+    if (!assessment) {
+      res.status(404).json({ error: 'Assessment not found.' });
+      return;
+    }
+
+    const overrideDiff = typeof req.body?.diff === 'string' ? req.body.diff : '';
+    const diffToApply = overrideDiff.trim() ? overrideDiff : assessment.suggestion.diff;
+
+    if (!diffToApply) {
+      res.status(400).json({ error: 'This assessment does not include a diff suggestion to apply.' });
+      return;
+    }
+
+    const result = await applySuggestionDiff(diffToApply, REPO_DIR);
+
+    res.setHeader('Cache-Control', 'no-store, max-age=0');
+    res.json({
+      success: true,
+      assessment: {
+        id: assessment.id,
+        title: assessment.title,
+        file: assessment.file
+      },
+      stdout: result.stdout,
+      stderr: result.stderr
+    });
+  } catch (error) {
+    const status = error.code === 'ENOENT' ? 404 : error.exitCode ? 409 : 500;
+    res.setHeader('Cache-Control', 'no-store, max-age=0');
+    res.status(status).json({
+      success: false,
+      error: status === 404 ? 'Review file not found.' : error.message,
+      stdout: error.stdout || '',
+      stderr: error.stderr || ''
+    });
+  }
+});
+
 app.get('/mtime', async (req, res) => {
   try {
     const stats = await fs.promises.stat(targetPath);
@@ -104,6 +194,7 @@ async function start() {
   app.listen(PORT, () => {
     console.log(`Auto Code Review Viewer listening on port ${PORT}`);
     console.log(`Rendering markdown from: ${targetPath}`);
+    console.log(`Applying suggestions to: ${REPO_DIR}`);
   });
 }
 

--- a/auto-review-viewer/app/server.js
+++ b/auto-review-viewer/app/server.js
@@ -1,8 +1,10 @@
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
+const { randomUUID } = require('crypto');
 const MarkdownIt = require('markdown-it');
 
+const logger = require('./logger');
 const { parseBadAssessments, applySuggestionDiff } = require('./review-utils');
 
 const app = express();
@@ -25,17 +27,40 @@ const md = new MarkdownIt({
 
 let cachedTemplate = null;
 
+function createRequestId() {
+  if (typeof randomUUID === 'function') {
+    try {
+      return randomUUID();
+    } catch (error) {
+      logger.logWarn('randomUUID threw error, falling back to timestamp-based id', { error });
+    }
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 async function loadTemplate() {
   if (cachedTemplate) {
+    logger.logDebug('Returning cached HTML template', { templatePath });
     return cachedTemplate;
   }
 
+  logger.logInfo('Loading HTML template from disk', { templatePath });
   cachedTemplate = await fs.promises.readFile(templatePath, 'utf8');
+  logger.logDebug('Template loaded from disk', {
+    templatePath,
+    bytes: cachedTemplate.length
+  });
   return cachedTemplate;
 }
 
 async function readMarkdownFile() {
-  return fs.promises.readFile(targetPath, 'utf8');
+  logger.logDebug('Reading markdown review file', { targetPath });
+  const content = await fs.promises.readFile(targetPath, 'utf8');
+  logger.logDebug('Finished reading markdown review file', {
+    targetPath,
+    bytes: content.length
+  });
+  return content;
 }
 
 function injectTemplate(template, renderedMarkdown) {
@@ -46,6 +71,13 @@ function injectTemplate(template, renderedMarkdown) {
 }
 
 app.get('/', async (req, res) => {
+  const requestId = createRequestId();
+  logger.logInfo('Received request for index page', {
+    requestId,
+    path: req.path,
+    method: req.method,
+    ip: req.ip
+  });
   try {
     const [template, markdown] = await Promise.all([
       loadTemplate(),
@@ -57,11 +89,17 @@ app.get('/', async (req, res) => {
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     res.setHeader('Cache-Control', 'no-store, must-revalidate');
     res.send(html);
+    logger.logInfo('Served index page successfully', { requestId });
   } catch (error) {
     const message = error.code === 'ENOENT'
       ? `Could not find markdown file at ${targetPath}`
       : 'Failed to render markdown file.';
     const details = error.message || 'Unknown error';
+    logger.logError('Failed to serve index page', {
+      requestId,
+      error,
+      message
+    });
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     res.setHeader('Cache-Control', 'no-store, must-revalidate');
     res.status(500).send(`<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Error</title><style>body{font-family:system-ui,sans-serif;padding:2rem;background:#f8f8f8;color:#111}pre{background:#fff;border-radius:0.5rem;padding:1rem;overflow:auto;border:1px solid #e5e5e5}</style></head><body><h1>Auto Code Review Viewer</h1><p>${message}</p><pre>${details}</pre></body></html>`);
@@ -69,12 +107,24 @@ app.get('/', async (req, res) => {
 });
 
 app.get('/api/assessments/bad', async (req, res) => {
+  const requestId = createRequestId();
+  logger.logInfo('Received request for bad assessments', {
+    requestId,
+    path: req.path,
+    method: req.method
+  });
   try {
     const [markdown, stats] = await Promise.all([
       readMarkdownFile(),
       fs.promises.stat(targetPath).catch(() => null)
     ]);
     const assessments = parseBadAssessments(markdown);
+
+    logger.logInfo('Returning bad assessments', {
+      requestId,
+      count: assessments.length,
+      updatedAt: stats ? stats.mtimeMs : null
+    });
 
     res.setHeader('Cache-Control', 'no-store, max-age=0');
     res.json({
@@ -95,6 +145,10 @@ app.get('/api/assessments/bad', async (req, res) => {
       }))
     });
   } catch (error) {
+    logger.logError('Failed to load bad assessments', {
+      requestId,
+      error
+    });
     const status = error.code === 'ENOENT' ? 404 : 500;
     res.setHeader('Cache-Control', 'no-store, max-age=0');
     res.status(status).json({
@@ -106,8 +160,19 @@ app.get('/api/assessments/bad', async (req, res) => {
 
 app.post('/api/assessments/:id/apply', async (req, res) => {
   const id = Number.parseInt(req.params.id, 10);
+  const requestId = createRequestId();
+  logger.logInfo('Received apply request', {
+    requestId,
+    method: req.method,
+    path: req.path,
+    id
+  });
   if (!Number.isFinite(id)) {
     res.status(400).json({ error: 'Invalid assessment identifier.' });
+    logger.logWarn('Rejecting apply request due to invalid identifier', {
+      requestId,
+      providedId: req.params.id
+    });
     return;
   }
 
@@ -118,6 +183,10 @@ app.post('/api/assessments/:id/apply', async (req, res) => {
 
     if (!assessment) {
       res.status(404).json({ error: 'Assessment not found.' });
+      logger.logWarn('Apply request referenced missing assessment', {
+        requestId,
+        id
+      });
       return;
     }
 
@@ -126,8 +195,23 @@ app.post('/api/assessments/:id/apply', async (req, res) => {
 
     if (!diffToApply) {
       res.status(400).json({ error: 'This assessment does not include a diff suggestion to apply.' });
+      logger.logWarn('Apply request missing diff suggestion', {
+        requestId,
+        id
+      });
       return;
     }
+
+    const diffPreview = diffToApply.length > 2000
+      ? `${diffToApply.slice(0, 2000)}…`
+      : diffToApply;
+    logger.logDebug('Preparing to apply suggestion diff', {
+      requestId,
+      id,
+      repoDir: REPO_DIR,
+      diffLength: diffToApply.length,
+      diffPreview
+    });
 
     const result = await applySuggestionDiff(diffToApply, REPO_DIR);
 
@@ -142,6 +226,13 @@ app.post('/api/assessments/:id/apply', async (req, res) => {
       stdout: result.stdout,
       stderr: result.stderr
     });
+    logger.logInfo('Applied suggestion successfully', {
+      requestId,
+      id,
+      file: assessment.file,
+      stdout: result.stdout,
+      stderr: result.stderr
+    });
   } catch (error) {
     const status = error.code === 'ENOENT' ? 404 : error.exitCode ? 409 : 500;
     res.setHeader('Cache-Control', 'no-store, max-age=0');
@@ -151,12 +242,50 @@ app.post('/api/assessments/:id/apply', async (req, res) => {
       stdout: error.stdout || '',
       stderr: error.stderr || ''
     });
+    logger.logError('Failed to apply suggestion', {
+      requestId,
+      id,
+      status,
+      error,
+      stdout: error.stdout,
+      stderr: error.stderr
+    });
   }
 });
 
+app.post('/api/logs', (req, res) => {
+  const requestId = createRequestId();
+  const payload = req.body && typeof req.body === 'object' ? req.body : {};
+  const eventType = typeof payload.eventType === 'string' ? payload.eventType : 'client_event';
+
+  logger.logInfo('Received client interaction log', {
+    requestId,
+    eventType,
+    viewerMode: typeof payload.viewerMode === 'string' ? payload.viewerMode : undefined,
+    timestamp: typeof payload.timestamp === 'number' ? payload.timestamp : undefined,
+    index: typeof payload.index === 'number' ? payload.index : undefined,
+    total: typeof payload.total === 'number' ? payload.total : undefined,
+    detail: payload.detail
+  });
+
+  res.setHeader('Cache-Control', 'no-store, max-age=0');
+  res.status(204).end();
+});
+
 app.get('/mtime', async (req, res) => {
+  const requestId = createRequestId();
+  logger.logDebug('Received mtime request', {
+    requestId,
+    method: req.method,
+    path: req.path
+  });
   try {
     const stats = await fs.promises.stat(targetPath);
+    logger.logInfo('Resolved mtime', {
+      requestId,
+      mtimeMs: stats.mtimeMs,
+      iso: stats.mtime.toISOString()
+    });
     res.setHeader('Cache-Control', 'no-store, max-age=0');
     res.json({
       file: FILENAME,
@@ -164,6 +293,10 @@ app.get('/mtime', async (req, res) => {
       iso: stats.mtime.toISOString()
     });
   } catch (error) {
+    logger.logError('Failed to resolve mtime', {
+      requestId,
+      error
+    });
     const status = error.code === 'ENOENT' ? 404 : 500;
     res.setHeader('Cache-Control', 'no-store, max-age=0');
     res.status(status).json({
@@ -174,27 +307,47 @@ app.get('/mtime', async (req, res) => {
 });
 
 app.get('/healthz', (req, res) => {
+  logger.logDebug('Health check request received', {
+    method: req.method,
+    path: req.path,
+    ip: req.ip
+  });
   res.setHeader('Cache-Control', 'no-store, max-age=0');
   res.json({ status: 'ok' });
 });
 
 function ensureSourceDirectory() {
   return fs.promises.access(targetPath, fs.constants.R_OK)
+    .then(() => {
+      logger.logInfo('Verified markdown source is accessible', { targetPath });
+    })
     .catch((error) => {
       const message = error.code === 'ENOENT'
         ? `Markdown file not found at ${targetPath}`
         : `Cannot read markdown file at ${targetPath}: ${error.message}`;
-      console.warn(message);
+      logger.logError('Failed to verify markdown source', {
+        targetPath,
+        error,
+        message
+      });
     });
 }
 
 async function start() {
   await ensureSourceDirectory();
 
+  logger.logInfo('Starting Auto Code Review Viewer server', {
+    port: PORT,
+    reviewFile: targetPath,
+    repoDirectory: REPO_DIR
+  });
+
   app.listen(PORT, () => {
-    console.log(`Auto Code Review Viewer listening on port ${PORT}`);
-    console.log(`Rendering markdown from: ${targetPath}`);
-    console.log(`Applying suggestions to: ${REPO_DIR}`);
+    logger.logInfo('Auto Code Review Viewer listening', {
+      port: PORT,
+      reviewFile: targetPath,
+      repoDirectory: REPO_DIR
+    });
   });
 }
 

--- a/auto-review-viewer/app/templates/index.html
+++ b/auto-review-viewer/app/templates/index.html
@@ -493,6 +493,50 @@
       let actionHelpVisible = false;
       let applyingSuggestion = false;
 
+      function createClientLogPayload(eventType, detail = {}) {
+        return {
+          eventType,
+          detail,
+          timestamp: Date.now(),
+          viewerMode: currentViewerMode,
+          index: actionState.currentIndex,
+          total: actionState.assessments.length
+        };
+      }
+
+      function sendClientLog(payload) {
+        try {
+          const body = JSON.stringify(payload);
+          if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function' && typeof Blob !== 'undefined') {
+            const blob = new Blob([body], { type: 'application/json' });
+            if (navigator.sendBeacon('/api/logs', blob)) {
+              return;
+            }
+          }
+          fetch('/api/logs', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body
+          }).catch((error) => {
+            console.warn('Failed to submit client log', error);
+          });
+        } catch (error) {
+          console.warn('Failed to prepare client log', error);
+        }
+      }
+
+      function logClientEvent(eventType, detail = {}) {
+        if (!eventType) {
+          return;
+        }
+        try {
+          const payload = createClientLogPayload(eventType, detail);
+          sendClientLog(payload);
+        } catch (error) {
+          console.warn('Failed to log client event', error);
+        }
+      }
+
       function applyReadingPreferences(prefs) {
         const root = document.documentElement;
         const fontSize = FONT_SIZE_OPTIONS[prefs.fontSize] || FONT_SIZE_OPTIONS[DEFAULT_READING_PREFS.fontSize];
@@ -672,6 +716,10 @@
           showReportView();
         }
         updateModeButtons(nextMode);
+        logClientEvent('set_viewer_mode', {
+          mode: nextMode,
+          skipStorage: Boolean(options.skipStorage)
+        });
       }
 
       function showActionEmpty(message) {
@@ -692,10 +740,20 @@
       function markAssessmentStatus(index, status) {
         const target = actionState.assessments[index];
         if (!target) {
+          logClientEvent('assessment_status_missing', {
+            index,
+            status,
+            total: actionState.assessments.length
+          });
           return;
         }
         target.status = status;
         target.updatedAt = Date.now();
+        logClientEvent('assessment_status_updated', {
+          id: target.id,
+          index,
+          status
+        });
       }
 
       function updateActionSummary() {
@@ -861,39 +919,93 @@
             actionApplyButton.textContent = 'Apply (A)';
           }
         }
+        logClientEvent('view_assessment', {
+          id: current.id,
+          index: actionState.currentIndex,
+          status: current.status || 'pending',
+          file: current.file || '',
+          hasDiff: Boolean(current.suggestion?.diff)
+        });
       }
 
       function setCurrentIndex(index) {
-        if (!Number.isInteger(index) || index < 0 || index >= actionState.assessments.length) {
+        if (!Number.isInteger(index)) {
+          logClientEvent('set_index_invalid', {
+            requestedIndex: index,
+            total: actionState.assessments.length
+          });
           return;
         }
+        if (index < 0 || index >= actionState.assessments.length) {
+          logClientEvent('set_index_out_of_bounds', {
+            requestedIndex: index,
+            total: actionState.assessments.length
+          });
+          return;
+        }
+        const target = actionState.assessments[index];
         actionState.currentIndex = index;
+        logClientEvent('jump_to_assessment', {
+          id: target?.id,
+          index,
+          status: target?.status || 'pending'
+        });
         updateActionView();
       }
 
       function goNext() {
-        if (actionState.currentIndex < actionState.assessments.length - 1) {
+        const total = actionState.assessments.length;
+        if (total === 0) {
+          logClientEvent('navigate_next_empty', { total });
+          return false;
+        }
+        if (actionState.currentIndex < total - 1) {
           actionState.currentIndex += 1;
+          logClientEvent('navigate_next', {
+            index: actionState.currentIndex,
+            total
+          });
           updateActionView();
           return true;
         }
+        logClientEvent('navigate_next_boundary', {
+          index: actionState.currentIndex,
+          total
+        });
         return false;
       }
 
       function goPrevious() {
+        const total = actionState.assessments.length;
+        if (total === 0) {
+          logClientEvent('navigate_previous_empty', { total });
+          return false;
+        }
         if (actionState.currentIndex > 0) {
           actionState.currentIndex -= 1;
+          logClientEvent('navigate_previous', {
+            index: actionState.currentIndex,
+            total
+          });
           updateActionView();
           return true;
         }
+        logClientEvent('navigate_previous_boundary', {
+          index: actionState.currentIndex,
+          total
+        });
         return false;
       }
 
       async function loadBadAssessments() {
         if (actionState.loading) {
+          logClientEvent('load_bad_assessments_skip', {
+            reason: 'in_progress'
+          });
           return;
         }
         actionState.loading = true;
+        logClientEvent('load_bad_assessments_start', {});
         showActionEmpty('Loading bad assessments…');
         setActionFeedback('info', 'Loading suggestions…');
         try {
@@ -912,6 +1024,10 @@
           }));
           actionState.loaded = true;
           actionState.updatedAt = typeof payload.updatedAt === 'number' ? payload.updatedAt : null;
+          logClientEvent('load_bad_assessments_success', {
+            count: actionState.assessments.length,
+            updatedAt: actionState.updatedAt
+          });
           if (actionState.assessments.length === 0) {
             setActionFeedback('info', 'No bad assessments were detected in this review.');
             showActionEmpty('No bad assessments were found. Switch back to Report mode to read the full review.');
@@ -922,14 +1038,25 @@
           }
         } catch (error) {
           console.error('Failed to load assessments', error);
+          logClientEvent('load_bad_assessments_error', {
+            message: error.message || 'Unknown error'
+          });
           setActionFeedback('error', error.message || 'Failed to load bad assessments.');
           showActionEmpty('Could not load bad assessments. Try refreshing the page.');
         } finally {
           actionState.loading = false;
+          logClientEvent('load_bad_assessments_complete', {
+            count: actionState.assessments.length,
+            loaded: actionState.loaded
+          });
         }
       }
 
       async function ensureActionData() {
+        logClientEvent('ensure_action_data', {
+          loaded: actionState.loaded,
+          count: actionState.assessments.length
+        });
         if (actionState.loaded) {
           if (actionState.assessments.length > 0) {
             updateActionView();
@@ -942,10 +1069,27 @@
       }
 
       function handleSkip() {
-        if (applyingSuggestion || !actionState.assessments.length) {
+        if (applyingSuggestion) {
+          logClientEvent('skip_blocked', { reason: 'applying' });
+          return;
+        }
+        if (!actionState.assessments.length) {
+          logClientEvent('skip_blocked', { reason: 'empty' });
           return;
         }
         const current = actionState.assessments[actionState.currentIndex];
+        if (!current) {
+          logClientEvent('skip_missing_assessment', {
+            index: actionState.currentIndex,
+            total: actionState.assessments.length
+          });
+          return;
+        }
+        logClientEvent('skip_assessment', {
+          id: current.id,
+          index: actionState.currentIndex,
+          file: current.file || ''
+        });
         markAssessmentStatus(actionState.currentIndex, 'skipped');
         setActionFeedback('info', `Skipped ${current.title || `assessment ${current.id}`}.`);
         if (!goNext()) {
@@ -954,14 +1098,29 @@
       }
 
       async function handleApply() {
-        if (applyingSuggestion || !actionState.assessments.length) {
+        if (applyingSuggestion) {
+          logClientEvent('apply_blocked', { reason: 'in_progress' });
+          return;
+        }
+        if (!actionState.assessments.length) {
+          logClientEvent('apply_blocked', { reason: 'empty' });
           return;
         }
         const current = actionState.assessments[actionState.currentIndex];
         if (!current || !current.suggestion || !current.suggestion.diff) {
+          logClientEvent('apply_blocked', {
+            reason: 'missing_diff',
+            id: current?.id,
+            index: actionState.currentIndex
+          });
           setActionFeedback('error', 'No diff suggestion is available for this assessment.');
           return;
         }
+        logClientEvent('apply_attempt', {
+          id: current.id,
+          index: actionState.currentIndex,
+          file: current.file || ''
+        });
         applyingSuggestion = true;
         updateActionView();
         const fileLabel = current.file ? ` for ${current.file}` : '';
@@ -979,6 +1138,11 @@
               : `Apply failed with status ${response.status}`;
             throw new Error(message);
           }
+          logClientEvent('apply_success', {
+            id: current.id,
+            stdoutLength: typeof payload.stdout === 'string' ? payload.stdout.length : 0,
+            stderrLength: typeof payload.stderr === 'string' ? payload.stderr.length : 0
+          });
           markAssessmentStatus(actionState.currentIndex, 'applied');
           setActionFeedback('success', `Applied suggestion${fileLabel}.`);
           if (!goNext()) {
@@ -986,11 +1150,20 @@
           }
         } catch (error) {
           console.error('Failed to apply suggestion', error);
+          logClientEvent('apply_failure', {
+            id: current?.id,
+            message: error.message || 'Unknown error'
+          });
           setActionFeedback('error', error.message || 'Failed to apply suggestion.');
           updateActionView();
         } finally {
           applyingSuggestion = false;
           updateActionView();
+          const updated = actionState.assessments[actionState.currentIndex];
+          logClientEvent('apply_complete', {
+            id: current?.id,
+            status: updated?.status || current?.status || 'unknown'
+          });
         }
       }
 
@@ -1002,6 +1175,10 @@
         actionHelpPanel.setAttribute('aria-hidden', 'false');
         actionHelpVisible = true;
         actionHelpButton?.setAttribute('aria-expanded', 'true');
+        logClientEvent('show_help_panel', {
+          index: actionState.currentIndex,
+          total: actionState.assessments.length
+        });
         try {
           actionHelpPanel.focus({ preventScroll: true });
         } catch (error) {
@@ -1017,6 +1194,10 @@
         actionHelpPanel.setAttribute('aria-hidden', 'true');
         actionHelpVisible = false;
         actionHelpButton?.setAttribute('aria-expanded', 'false');
+        logClientEvent('hide_help_panel', {
+          index: actionState.currentIndex,
+          total: actionState.assessments.length
+        });
       }
 
       function toggleHelpPanel() {

--- a/auto-review-viewer/app/templates/index.html
+++ b/auto-review-viewer/app/templates/index.html
@@ -215,13 +215,182 @@
         </div>
       </header>
       <main class="flex-1">
-        <div class="mx-auto w-full max-w-4xl px-4 pb-10 pt-6 sm:px-6">
-          <article
-            class="acr-content prose-sm prose-slate max-w-none dark:prose-invert"
-            style="font-size: var(--acr-font-size); line-height: var(--acr-line-height);"
-          >
-            {{CONTENT}}
-          </article>
+        <div class="mx-auto w-full max-w-6xl px-4 pb-12 pt-6 sm:px-6">
+          <div class="mb-6 flex flex-wrap items-center justify-between gap-3">
+            <div
+              class="inline-flex rounded-full border border-slate-200 bg-white p-1 text-sm font-medium shadow-sm dark:border-slate-700 dark:bg-slate-900"
+              role="group"
+              aria-label="Viewer mode"
+            >
+              <button
+                id="mode-report"
+                type="button"
+                data-viewer-mode="report"
+                class="mode-toggle-button inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500"
+              >
+                <span>Report</span>
+              </button>
+              <button
+                id="mode-action"
+                type="button"
+                data-viewer-mode="action"
+                class="mode-toggle-button inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500"
+              >
+                <span>Action</span>
+              </button>
+            </div>
+            <div class="text-xs text-slate-500 dark:text-slate-400">
+              Use Action mode to apply suggestions. Hotkeys activate while Action mode is open.
+            </div>
+          </div>
+          <section id="report-view">
+            <article
+              class="acr-content prose-sm prose-slate max-w-none dark:prose-invert"
+              style="font-size: var(--acr-font-size); line-height: var(--acr-line-height);"
+            >
+              {{CONTENT}}
+            </article>
+          </section>
+          <section id="action-view" class="space-y-6" hidden>
+            <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+              <div class="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                  <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-100">Action mode</h2>
+                  <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                    Step through each bad assessment and apply its suggested diff.
+                  </p>
+                </div>
+                <div class="flex items-center gap-2">
+                  <button
+                    id="action-help-button"
+                    type="button"
+                    class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:border-slate-300 hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:border-slate-600 dark:hover:bg-slate-700"
+                  >
+                    <span>Help</span>
+                    <span class="rounded-full bg-slate-200 px-1.5 py-0.5 text-xs font-semibold text-slate-700 dark:bg-slate-700 dark:text-slate-200">?</span>
+                  </button>
+                </div>
+              </div>
+              <div id="action-count" class="mt-3 text-xs text-slate-500 dark:text-slate-400"></div>
+            </div>
+            <div id="action-feedback" class="hidden rounded-2xl border px-4 py-3 text-sm"></div>
+            <div
+              id="action-empty"
+              class="rounded-2xl border border-dashed border-slate-300 bg-white/60 p-8 text-center text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300"
+            >
+              Loading bad assessments…
+            </div>
+            <div id="action-body" class="space-y-5" hidden>
+              <div class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+                <div class="flex flex-wrap items-center justify-between gap-3">
+                  <div id="action-progress" class="text-sm font-semibold text-slate-700 dark:text-slate-200"></div>
+                  <div id="action-status-summary" class="text-xs text-slate-500 dark:text-slate-400"></div>
+                </div>
+                <div id="action-status-list" class="mt-3 flex flex-wrap gap-2"></div>
+              </div>
+              <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+                <div class="flex flex-col gap-4">
+                  <div>
+                    <h3 id="action-title" class="text-xl font-semibold text-slate-800 dark:text-slate-100"></h3>
+                    <div class="mt-2 flex flex-wrap gap-2 text-xs font-medium">
+                      <span
+                        id="action-file"
+                        class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-3 py-1 text-slate-600 dark:bg-slate-800 dark:text-slate-200"
+                      ></span>
+                      <span
+                        id="action-lines"
+                        class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-3 py-1 text-slate-600 dark:bg-slate-800 dark:text-slate-200"
+                      ></span>
+                      <span
+                        id="action-function"
+                        class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-3 py-1 text-slate-600 dark:bg-slate-800 dark:text-slate-200"
+                      ></span>
+                    </div>
+                  </div>
+                  <div class="space-y-4 text-sm leading-relaxed text-slate-700 dark:text-slate-200">
+                    <div>
+                      <h4 class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Details</h4>
+                      <p id="action-details" class="mt-1 whitespace-pre-wrap"></p>
+                    </div>
+                    <div>
+                      <h4 class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Suggestion</h4>
+                      <p id="action-suggestion-text" class="mt-1 whitespace-pre-wrap"></p>
+                      <div
+                        id="action-diff"
+                        class="mt-3 hidden overflow-hidden rounded-xl border border-slate-200 dark:border-slate-700"
+                      ></div>
+                    </div>
+                    <div>
+                      <h4 class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Reasoning</h4>
+                      <p id="action-reasoning" class="mt-1 whitespace-pre-wrap"></p>
+                    </div>
+                  </div>
+                </div>
+                <div class="mt-5 flex flex-wrap items-center justify-between gap-3">
+                  <div class="flex flex-wrap gap-2">
+                    <button
+                      id="action-prev"
+                      type="button"
+                      class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:border-slate-600 dark:hover:bg-slate-700"
+                    >
+                      ◀ Previous (P)
+                    </button>
+                    <button
+                      id="action-next"
+                      type="button"
+                      class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:border-slate-600 dark:hover:bg-slate-700"
+                    >
+                      Next (N) ▶
+                    </button>
+                  </div>
+                  <div class="flex flex-wrap gap-2">
+                    <button
+                      id="action-apply"
+                      type="button"
+                      class="inline-flex items-center gap-2 rounded-full border border-emerald-500 bg-emerald-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      Apply (A)
+                    </button>
+                    <button
+                      id="action-skip"
+                      type="button"
+                      class="inline-flex items-center gap-2 rounded-full border border-amber-400 bg-amber-100 px-4 py-2 text-sm font-semibold text-amber-700 transition hover:bg-amber-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-amber-500 dark:bg-amber-500/20 dark:text-amber-200"
+                    >
+                      Skip (S)
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              id="action-help-panel"
+              class="hidden rounded-2xl border border-slate-200 bg-white p-5 text-sm shadow-xl focus:outline-none dark:border-slate-800 dark:bg-slate-900"
+              tabindex="-1"
+              role="dialog"
+              aria-modal="false"
+            >
+              <div class="flex items-center justify-between gap-3">
+                <h3 class="text-base font-semibold text-slate-800 dark:text-slate-100">Keyboard shortcuts</h3>
+                <button
+                  id="action-help-close"
+                  type="button"
+                  class="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:border-slate-600 dark:hover:bg-slate-700"
+                >
+                  Close
+                </button>
+              </div>
+              <ul class="mt-4 space-y-2 text-slate-600 dark:text-slate-300">
+                <li><span class="font-semibold">N</span> – Next assessment</li>
+                <li><span class="font-semibold">P</span> – Previous assessment</li>
+                <li><span class="font-semibold">A</span> – Apply suggestion</li>
+                <li><span class="font-semibold">S</span> – Skip assessment</li>
+                <li><span class="font-semibold">?</span> – Toggle this help</li>
+              </ul>
+              <p class="mt-4 text-xs text-slate-500 dark:text-slate-400">
+                Actions update the status list above so you can see what has been applied or skipped.
+              </p>
+            </div>
+          </section>
         </div>
       </main>
       <footer class="border-t border-slate-200/70 bg-white/70 py-3 text-sm text-slate-500 backdrop-blur dark:border-slate-800/60 dark:bg-slate-950/70 dark:text-slate-400">
@@ -244,6 +413,31 @@
       const settingsPanel = document.getElementById('settings-panel');
       const fontSizeSelect = document.getElementById('font-size-select');
       const lineSpacingSelect = document.getElementById('line-spacing-select');
+      const reportView = document.getElementById('report-view');
+      const actionView = document.getElementById('action-view');
+      const actionBody = document.getElementById('action-body');
+      const actionEmpty = document.getElementById('action-empty');
+      const actionFeedback = document.getElementById('action-feedback');
+      const actionProgress = document.getElementById('action-progress');
+      const actionStatusList = document.getElementById('action-status-list');
+      const actionStatusSummary = document.getElementById('action-status-summary');
+      const actionTitle = document.getElementById('action-title');
+      const actionFile = document.getElementById('action-file');
+      const actionLines = document.getElementById('action-lines');
+      const actionFunction = document.getElementById('action-function');
+      const actionDetails = document.getElementById('action-details');
+      const actionSuggestionText = document.getElementById('action-suggestion-text');
+      const actionReasoning = document.getElementById('action-reasoning');
+      const actionDiffContainer = document.getElementById('action-diff');
+      const actionCountLabel = document.getElementById('action-count');
+      const actionPrevButton = document.getElementById('action-prev');
+      const actionNextButton = document.getElementById('action-next');
+      const actionApplyButton = document.getElementById('action-apply');
+      const actionSkipButton = document.getElementById('action-skip');
+      const actionHelpButton = document.getElementById('action-help-button');
+      const actionHelpPanel = document.getElementById('action-help-panel');
+      const actionHelpClose = document.getElementById('action-help-close');
+      const modeToggleButtons = document.querySelectorAll('[data-viewer-mode]');
 
       const FONT_SIZE_OPTIONS = {
         sm: '0.875rem',
@@ -261,6 +455,43 @@
         fontSize: 'sm',
         lineSpacing: 'cozy'
       };
+
+      const MODE_STORAGE_KEY = 'acr-view-mode';
+      const MODE_BUTTON_ACTIVE_CLASSES = ['bg-brand-500', 'text-white', 'shadow'];
+      const MODE_BUTTON_INACTIVE_CLASSES = [
+        'bg-transparent',
+        'text-slate-600',
+        'hover:bg-slate-100',
+        'dark:text-slate-300',
+        'dark:hover:bg-slate-800'
+      ];
+      const STATUS_CLASS_MAP = {
+        pending: ['border-slate-200', 'bg-white', 'text-slate-500', 'dark:border-slate-700', 'dark:bg-slate-900', 'dark:text-slate-300'],
+        applied: ['border-emerald-500', 'bg-emerald-50', 'text-emerald-700', 'dark:border-emerald-400/70', 'dark:bg-emerald-500/10', 'dark:text-emerald-200'],
+        skipped: ['border-amber-500', 'bg-amber-50', 'text-amber-700', 'dark:border-amber-400/70', 'dark:bg-amber-500/10', 'dark:text-amber-200']
+      };
+      const STATUS_SYMBOLS = {
+        pending: '',
+        applied: '✓',
+        skipped: '↷'
+      };
+      const FEEDBACK_CLASS_MAP = {
+        success: ['border-emerald-500', 'bg-emerald-50', 'text-emerald-700', 'dark:border-emerald-400/70', 'dark:bg-emerald-500/10', 'dark:text-emerald-200'],
+        error: ['border-rose-500', 'bg-rose-50', 'text-rose-700', 'dark:border-rose-400/70', 'dark:bg-rose-500/10', 'dark:text-rose-200'],
+        info: ['border-slate-300', 'bg-slate-100', 'text-slate-700', 'dark:border-slate-600', 'dark:bg-slate-800', 'dark:text-slate-200']
+      };
+      const ALL_FEEDBACK_CLASSES = Array.from(new Set(Object.values(FEEDBACK_CLASS_MAP).flat()));
+
+      const actionState = {
+        loading: false,
+        loaded: false,
+        assessments: [],
+        currentIndex: 0,
+        updatedAt: null
+      };
+      let currentViewerMode = 'report';
+      let actionHelpVisible = false;
+      let applyingSuggestion = false;
 
       function applyReadingPreferences(prefs) {
         const root = document.documentElement;
@@ -367,8 +598,508 @@
       document.addEventListener('keydown', (event) => {
         if (event.key === 'Escape') {
           setSettingsPanelVisibility(false);
+          hideHelpPanel();
         }
       });
+
+      function getStoredMode() {
+        try {
+          const stored = window.localStorage.getItem(MODE_STORAGE_KEY);
+          if (stored === 'action' || stored === 'report') {
+            return stored;
+          }
+        } catch (error) {
+          console.warn('Failed to read viewer mode from storage', error);
+        }
+        return 'report';
+      }
+
+      function persistViewerMode(mode) {
+        try {
+          window.localStorage.setItem(MODE_STORAGE_KEY, mode);
+        } catch (error) {
+          console.warn('Failed to store viewer mode', error);
+        }
+      }
+
+      function setActionFeedback(type, message) {
+        if (!actionFeedback) {
+          return;
+        }
+        ALL_FEEDBACK_CLASSES.forEach((cls) => actionFeedback.classList.remove(cls));
+        if (!message) {
+          actionFeedback.classList.add('hidden');
+          actionFeedback.textContent = '';
+          return;
+        }
+        const classes = FEEDBACK_CLASS_MAP[type] || FEEDBACK_CLASS_MAP.info;
+        classes.forEach((cls) => actionFeedback.classList.add(cls));
+        actionFeedback.textContent = message;
+        actionFeedback.classList.remove('hidden');
+      }
+
+      function updateModeButtons(mode) {
+        modeToggleButtons.forEach((button) => {
+          const buttonMode = button.dataset.viewerMode === 'action' ? 'action' : 'report';
+          const isActive = buttonMode === mode;
+          MODE_BUTTON_ACTIVE_CLASSES.forEach((cls) => button.classList.toggle(cls, isActive));
+          MODE_BUTTON_INACTIVE_CLASSES.forEach((cls) => button.classList.toggle(cls, !isActive));
+          button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+      }
+
+      function showReportView() {
+        reportView?.removeAttribute('hidden');
+        actionView?.setAttribute('hidden', '');
+        hideHelpPanel();
+      }
+
+      function showActionView() {
+        reportView?.setAttribute('hidden', '');
+        actionView?.removeAttribute('hidden');
+        ensureActionData();
+      }
+
+      function setViewerMode(mode, options = {}) {
+        const nextMode = mode === 'action' ? 'action' : 'report';
+        currentViewerMode = nextMode;
+        if (!options.skipStorage) {
+          persistViewerMode(nextMode);
+        }
+        if (nextMode === 'action') {
+          showActionView();
+        } else {
+          showReportView();
+        }
+        updateModeButtons(nextMode);
+      }
+
+      function showActionEmpty(message) {
+        if (actionEmpty) {
+          if (typeof message === 'string') {
+            actionEmpty.textContent = message;
+          }
+          actionEmpty.removeAttribute('hidden');
+        }
+        actionBody?.setAttribute('hidden', '');
+      }
+
+      function hideActionEmpty() {
+        actionEmpty?.setAttribute('hidden', '');
+        actionBody?.removeAttribute('hidden');
+      }
+
+      function markAssessmentStatus(index, status) {
+        const target = actionState.assessments[index];
+        if (!target) {
+          return;
+        }
+        target.status = status;
+        target.updatedAt = Date.now();
+      }
+
+      function updateActionSummary() {
+        if (!actionStatusSummary) {
+          return;
+        }
+        const total = actionState.assessments.length;
+        if (!total) {
+          actionStatusSummary.textContent = '';
+          return;
+        }
+        let applied = 0;
+        let skipped = 0;
+        actionState.assessments.forEach((assessment) => {
+          if (assessment.status === 'applied') {
+            applied += 1;
+          } else if (assessment.status === 'skipped') {
+            skipped += 1;
+          }
+        });
+        const pending = total - applied - skipped;
+        actionStatusSummary.textContent = `Applied ${applied} · Skipped ${skipped} · Pending ${pending}`;
+      }
+
+      function renderStatusChips() {
+        if (!actionStatusList) {
+          return;
+        }
+        actionStatusList.innerHTML = '';
+        actionState.assessments.forEach((assessment, index) => {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className =
+            'inline-flex min-w-[2.5rem] items-center justify-center rounded-full border px-3 py-1 text-xs font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500';
+          const status = assessment.status || 'pending';
+          const classes = STATUS_CLASS_MAP[status] || STATUS_CLASS_MAP.pending;
+          classes.forEach((cls) => button.classList.add(cls));
+          if (index === actionState.currentIndex) {
+            button.classList.add('ring-2', 'ring-brand-500', 'ring-offset-2', 'ring-offset-white', 'dark:ring-offset-slate-900');
+          }
+          const symbol = STATUS_SYMBOLS[status] || '';
+          button.innerHTML = `<span class="font-semibold">${index + 1}</span>${symbol ? `<span class="ml-1 text-[11px]">${symbol}</span>` : ''}`;
+          button.dataset.index = String(index);
+          button.title = assessment.title ? `${assessment.title} (${status})` : `Assessment ${index + 1}`;
+          button.addEventListener('click', () => {
+            setCurrentIndex(index);
+          });
+          actionStatusList.appendChild(button);
+        });
+      }
+
+      function setMetaBadge(element, prefix, value) {
+        if (!element) {
+          return;
+        }
+        if (value) {
+          element.textContent = prefix ? `${prefix}${value}` : value;
+          element.classList.remove('hidden');
+        } else {
+          element.textContent = '';
+          element.classList.add('hidden');
+        }
+      }
+
+      function updateActionCountLabel(total) {
+        if (!actionCountLabel) {
+          return;
+        }
+        if (!total) {
+          actionCountLabel.textContent = '';
+          return;
+        }
+        const parts = [`Loaded ${total} bad assessment${total === 1 ? '' : 's'}.`];
+        if (actionState.updatedAt) {
+          parts.push(`Last updated ${formatTimestamp(actionState.updatedAt)}`);
+        }
+        actionCountLabel.textContent = parts.join(' ');
+      }
+
+      function updateActionView() {
+        if (!actionBody) {
+          return;
+        }
+        const total = actionState.assessments.length;
+        if (!total) {
+          updateActionCountLabel(0);
+          showActionEmpty('No bad assessments were found. Switch back to Report mode to read the full review.');
+          setActionFeedback('', '');
+          return;
+        }
+        hideActionEmpty();
+        updateActionCountLabel(total);
+        if (actionState.currentIndex < 0 || actionState.currentIndex >= total) {
+          actionState.currentIndex = 0;
+        }
+        const current = actionState.assessments[actionState.currentIndex];
+        if (actionProgress) {
+          actionProgress.textContent = `Assessment ${actionState.currentIndex + 1} of ${total}`;
+        }
+        renderStatusChips();
+        updateActionSummary();
+        if (actionTitle) {
+          actionTitle.textContent = current.title || `Assessment ${actionState.currentIndex + 1}`;
+        }
+        setMetaBadge(actionFile, '📄 ', current.file || '');
+        setMetaBadge(actionLines, '📌 Lines ', current.lines || '');
+        setMetaBadge(actionFunction, 'ƒ ', current.function || '');
+        if (actionDetails) {
+          actionDetails.textContent = current.details || 'No additional details provided.';
+        }
+        if (actionSuggestionText) {
+          actionSuggestionText.textContent = current.suggestion?.text || 'Suggestion is provided as a diff.';
+        }
+        if (actionReasoning) {
+          actionReasoning.textContent = current.reasoning || 'No reasoning supplied.';
+        }
+        if (actionDiffContainer) {
+          actionDiffContainer.innerHTML = '';
+          actionDiffContainer.classList.add('hidden');
+          if (current.suggestion && current.suggestion.diff) {
+            const pre = document.createElement('pre');
+            const code = document.createElement('code');
+            code.className = 'language-diff';
+            const diffText = current.suggestion.diff.endsWith('\n')
+              ? current.suggestion.diff
+              : `${current.suggestion.diff}\n`;
+            code.textContent = diffText;
+            pre.appendChild(code);
+            actionDiffContainer.appendChild(pre);
+            actionDiffContainer.classList.remove('hidden');
+            try {
+              if (window.hljs?.highlightElement) {
+                window.hljs.highlightElement(code);
+              }
+            } catch (error) {
+              console.warn('Failed to highlight diff', error);
+            }
+            try {
+              enhanceDiffBlocks();
+            } catch (error) {
+              console.warn('Failed to decorate diff block', error);
+            }
+          }
+        }
+        if (actionPrevButton) {
+          actionPrevButton.disabled = applyingSuggestion || actionState.currentIndex === 0;
+        }
+        if (actionNextButton) {
+          actionNextButton.disabled = applyingSuggestion || actionState.currentIndex >= total - 1;
+        }
+        if (actionSkipButton) {
+          actionSkipButton.disabled = applyingSuggestion;
+        }
+        if (actionApplyButton) {
+          if (applyingSuggestion) {
+            actionApplyButton.disabled = true;
+            actionApplyButton.textContent = 'Applying…';
+          } else if (current.status === 'applied') {
+            actionApplyButton.disabled = true;
+            actionApplyButton.textContent = 'Applied ✓';
+          } else {
+            actionApplyButton.disabled = false;
+            actionApplyButton.textContent = 'Apply (A)';
+          }
+        }
+      }
+
+      function setCurrentIndex(index) {
+        if (!Number.isInteger(index) || index < 0 || index >= actionState.assessments.length) {
+          return;
+        }
+        actionState.currentIndex = index;
+        updateActionView();
+      }
+
+      function goNext() {
+        if (actionState.currentIndex < actionState.assessments.length - 1) {
+          actionState.currentIndex += 1;
+          updateActionView();
+          return true;
+        }
+        return false;
+      }
+
+      function goPrevious() {
+        if (actionState.currentIndex > 0) {
+          actionState.currentIndex -= 1;
+          updateActionView();
+          return true;
+        }
+        return false;
+      }
+
+      async function loadBadAssessments() {
+        if (actionState.loading) {
+          return;
+        }
+        actionState.loading = true;
+        showActionEmpty('Loading bad assessments…');
+        setActionFeedback('info', 'Loading suggestions…');
+        try {
+          const response = await fetch('/api/assessments/bad', { cache: 'no-store' });
+          const payload = await response.json().catch(() => ({}));
+          if (!response.ok) {
+            const message = payload && typeof payload.error === 'string'
+              ? payload.error
+              : `Request failed with status ${response.status}`;
+            throw new Error(message);
+          }
+          const assessments = Array.isArray(payload.assessments) ? payload.assessments : [];
+          actionState.assessments = assessments.map((assessment) => ({
+            ...assessment,
+            status: 'pending'
+          }));
+          actionState.loaded = true;
+          actionState.updatedAt = typeof payload.updatedAt === 'number' ? payload.updatedAt : null;
+          if (actionState.assessments.length === 0) {
+            setActionFeedback('info', 'No bad assessments were detected in this review.');
+            showActionEmpty('No bad assessments were found. Switch back to Report mode to read the full review.');
+          } else {
+            setActionFeedback('success', `Loaded ${actionState.assessments.length} bad assessment${actionState.assessments.length === 1 ? '' : 's'}.`);
+            actionState.currentIndex = 0;
+            updateActionView();
+          }
+        } catch (error) {
+          console.error('Failed to load assessments', error);
+          setActionFeedback('error', error.message || 'Failed to load bad assessments.');
+          showActionEmpty('Could not load bad assessments. Try refreshing the page.');
+        } finally {
+          actionState.loading = false;
+        }
+      }
+
+      async function ensureActionData() {
+        if (actionState.loaded) {
+          if (actionState.assessments.length > 0) {
+            updateActionView();
+          } else {
+            showActionEmpty('No bad assessments were found. Switch back to Report mode to read the full review.');
+          }
+          return;
+        }
+        await loadBadAssessments();
+      }
+
+      function handleSkip() {
+        if (applyingSuggestion || !actionState.assessments.length) {
+          return;
+        }
+        const current = actionState.assessments[actionState.currentIndex];
+        markAssessmentStatus(actionState.currentIndex, 'skipped');
+        setActionFeedback('info', `Skipped ${current.title || `assessment ${current.id}`}.`);
+        if (!goNext()) {
+          updateActionView();
+        }
+      }
+
+      async function handleApply() {
+        if (applyingSuggestion || !actionState.assessments.length) {
+          return;
+        }
+        const current = actionState.assessments[actionState.currentIndex];
+        if (!current || !current.suggestion || !current.suggestion.diff) {
+          setActionFeedback('error', 'No diff suggestion is available for this assessment.');
+          return;
+        }
+        applyingSuggestion = true;
+        updateActionView();
+        const fileLabel = current.file ? ` for ${current.file}` : '';
+        setActionFeedback('info', `Applying suggestion${fileLabel}…`);
+        try {
+          const response = await fetch(`/api/assessments/${current.id}/apply`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({})
+          });
+          const payload = await response.json().catch(() => ({}));
+          if (!response.ok || payload.success !== true) {
+            const message = payload && typeof payload.error === 'string'
+              ? payload.error
+              : `Apply failed with status ${response.status}`;
+            throw new Error(message);
+          }
+          markAssessmentStatus(actionState.currentIndex, 'applied');
+          setActionFeedback('success', `Applied suggestion${fileLabel}.`);
+          if (!goNext()) {
+            updateActionView();
+          }
+        } catch (error) {
+          console.error('Failed to apply suggestion', error);
+          setActionFeedback('error', error.message || 'Failed to apply suggestion.');
+          updateActionView();
+        } finally {
+          applyingSuggestion = false;
+          updateActionView();
+        }
+      }
+
+      function showHelpPanel() {
+        if (!actionHelpPanel) {
+          return;
+        }
+        actionHelpPanel.classList.remove('hidden');
+        actionHelpPanel.setAttribute('aria-hidden', 'false');
+        actionHelpVisible = true;
+        actionHelpButton?.setAttribute('aria-expanded', 'true');
+        try {
+          actionHelpPanel.focus({ preventScroll: true });
+        } catch (error) {
+          actionHelpPanel.focus();
+        }
+      }
+
+      function hideHelpPanel() {
+        if (!actionHelpPanel) {
+          return;
+        }
+        actionHelpPanel.classList.add('hidden');
+        actionHelpPanel.setAttribute('aria-hidden', 'true');
+        actionHelpVisible = false;
+        actionHelpButton?.setAttribute('aria-expanded', 'false');
+      }
+
+      function toggleHelpPanel() {
+        if (actionHelpVisible) {
+          hideHelpPanel();
+        } else {
+          showHelpPanel();
+        }
+      }
+
+      function handleActionHotkeys(event) {
+        if (currentViewerMode !== 'action') {
+          return;
+        }
+        if (event.metaKey || event.ctrlKey || event.altKey || event.defaultPrevented) {
+          return;
+        }
+        const target = event.target;
+        const tagName = target && target.tagName ? target.tagName.toLowerCase() : '';
+        if (tagName === 'input' || tagName === 'textarea' || target?.isContentEditable) {
+          return;
+        }
+        const key = event.key || '';
+        if (key === '?') {
+          event.preventDefault();
+          toggleHelpPanel();
+          return;
+        }
+        if (key === '/' && event.shiftKey) {
+          event.preventDefault();
+          toggleHelpPanel();
+          return;
+        }
+        const lower = key.toLowerCase();
+        if (lower === 'n') {
+          event.preventDefault();
+          goNext();
+        } else if (lower === 'p') {
+          event.preventDefault();
+          goPrevious();
+        } else if (lower === 's') {
+          event.preventDefault();
+          handleSkip();
+        } else if (lower === 'a') {
+          event.preventDefault();
+          handleApply();
+        }
+      }
+
+      modeToggleButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const mode = button.dataset.viewerMode === 'action' ? 'action' : 'report';
+          setViewerMode(mode);
+        });
+      });
+
+      actionPrevButton?.addEventListener('click', () => {
+        goPrevious();
+      });
+
+      actionNextButton?.addEventListener('click', () => {
+        goNext();
+      });
+
+      actionSkipButton?.addEventListener('click', () => {
+        handleSkip();
+      });
+
+      actionApplyButton?.addEventListener('click', () => {
+        handleApply();
+      });
+
+      actionHelpButton?.addEventListener('click', () => {
+        toggleHelpPanel();
+      });
+
+      actionHelpClose?.addEventListener('click', () => {
+        hideHelpPanel();
+      });
+
+      document.addEventListener('keydown', handleActionHotkeys);
+
+      setViewerMode(getStoredMode(), { skipStorage: true });
 
       function applyHighlightTheme(mode) {
         if (!hljsLight || !hljsDark) return;

--- a/auto-review-viewer/app/test/review-utils.test.js
+++ b/auto-review-viewer/app/test/review-utils.test.js
@@ -1,0 +1,105 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const os = require('node:os');
+const { promisify } = require('node:util');
+const { execFile } = require('node:child_process');
+
+const { parseBadAssessments, applySuggestionDiff } = require('../review-utils');
+
+const execFileAsync = promisify(execFile);
+
+test('parseBadAssessments extracts BAD assessments with metadata and diff', () => {
+  const sample = `## Change-by-Change Review
+
+### Assessment of the change: BAD
+**title:** Fix logging bug
+**file:** src/app.js
+**function:** logMessage
+**Lines:** 10-15
+**Details:** Logging uses the wrong level.
+**Suggestion (if 'BAD'):** Apply this minimal patch:
+\`\`\`diff
+--- a/src/app.js
++++ b/src/app.js
+@@ -10,3 +10,3 @@
+-console.log('debug');
++console.error('debug');
+\`\`\`
+**Reasoning (if 'BAD'):** Use error logs for failures.
+---
+
+### Assessment of the change: GOOD
+**title:** Keep helper intact
+**file:** src/util.js
+**function:** helper
+**Lines:** 1-5
+**Details:** Looks good.
+---
+
+### Assessment of the change: BAD
+**title:** Add missing tests
+**file:** src/app.test.js
+**function:** shouldLogError
+**Lines:** 30-60
+**Details:** Coverage is missing.
+**Suggestion (if 'BAD'):** Please add unit tests.
+**Reasoning (if 'BAD'):** Maintain coverage.
+---
+`;
+
+  const assessments = parseBadAssessments(sample);
+  assert.equal(assessments.length, 2);
+
+  const first = assessments[0];
+  assert.equal(first.id, 1);
+  assert.equal(first.position, 1);
+  assert.equal(first.title, 'Fix logging bug');
+  assert.equal(first.file, 'src/app.js');
+  assert.equal(first.function, 'logMessage');
+  assert.equal(first.lines, '10-15');
+  assert.match(first.suggestion.text, /Apply this minimal patch/);
+  assert.ok(first.suggestion.diff);
+  assert.match(first.suggestion.diff, /console\.error/);
+
+  const second = assessments[1];
+  assert.equal(second.id, 2);
+  assert.equal(second.position, 3);
+  assert.equal(second.file, 'src/app.test.js');
+  assert.equal(second.suggestion.diff, null);
+  assert.match(second.details, /Coverage is missing/);
+});
+
+test('applySuggestionDiff applies diff inside a git repository', async () => {
+  const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'review-utils-'));
+  const execGit = (args) => execFileAsync('git', args, { cwd: repoDir });
+
+  try {
+    await execGit(['init', '--quiet']);
+    await execGit(['config', 'user.email', 'test@example.com']);
+    await execGit(['config', 'user.name', 'Test User']);
+
+    const filePath = path.join(repoDir, 'sample.txt');
+    await fs.writeFile(filePath, 'hello\n', 'utf8');
+    await execGit(['add', 'sample.txt']);
+    await execGit(['commit', '-m', 'Initial commit', '--quiet']);
+
+    const diff = [
+      '--- a/sample.txt',
+      '+++ b/sample.txt',
+      '@@ -1 +1 @@',
+      '-hello',
+      '+hello world',
+      ''
+    ].join('\n');
+
+    await applySuggestionDiff(diff, repoDir);
+    const updated = await fs.readFile(filePath, 'utf8');
+    assert.equal(updated, 'hello world\n');
+
+    await assert.rejects(applySuggestionDiff(diff, repoDir));
+  } finally {
+    await fs.rm(repoDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a shared parser and git apply helper so the viewer can expose BAD assessments and apply their diffs
- extend the Express server with JSON endpoints for the action mode navigator and diff application
- replace the static report-only template with an action mode UI that supports keyboard navigation, hotkey help, and status tracking, plus add node:test coverage for the new logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ceaa270cbc832b9886d696876e9f87