### PR TITLE
Allow configuring review folder from UI

### DIFF
--- a/auto-review-viewer/Dockerfile
+++ b/auto-review-viewer/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /usr/src/app
 ENV NODE_ENV=production \
     SRC_DIR=/data \
     FILENAME=auto_code_review.md \
+    REPO_DIR=/data \
     PORT=3000
 
 COPY app/package*.json ./

--- a/auto-review-viewer/README.md
+++ b/auto-review-viewer/README.md
@@ -4,43 +4,44 @@ Render `auto_code_review.md` from a mounted directory with a polished, shareable
 
 ## Features
 
-- 📄 Reads Markdown from a mounted directory (`/data/auto_code_review.md` by default).
-- 🎨 Beautiful typography powered by Tailwind's typography plugin and highlight.js.
-- 🌓 Sticky header with live file path display and dark mode toggle.
-- 🔁 Automatic refresh when the source file changes (polls `GET /mtime`).
-- 💓 Health check endpoint at `GET /healthz` for container monitoring.
+- Reads Markdown from a mounted directory (defaults to `SRC_DIR`/`FILENAME`).
+- Clean typography with Tailwind and highlight.js.
+- Sticky header with live file path display and dark mode toggle.
+- Auto-refresh when the source file changes (polls `GET /mtime`).
+- Health check endpoint at `GET /healthz` for container monitoring.
 
 ## Project structure
 
 ```
 auto-review-viewer/
-├─ app/
-│  ├─ server.js
-│  ├─ package.json
-│  └─ templates/
-│     └─ index.html
-├─ Dockerfile
-├─ docker-compose.yml
-└─ README.md
+  app/
+    server.js
+    package.json
+    templates/
+      index.html
+  Dockerfile
+  docker-compose.yml
+  README.md
 ```
 
 ## Configuration
 
-| Variable   | Default                | Description                                   |
-|------------|------------------------|-----------------------------------------------|
-| `SRC_DIR`  | `/data`                | Directory inside the container to read from. |
-| `FILENAME` | `auto_code_review.md`  | File name to render inside `SRC_DIR`.         |
-| `PORT`     | `3000`                 | Port exposed by the Express server.          |
+| Variable   | Default               | Description                                  |
+|----------- |-----------------------|----------------------------------------------|
+| `SRC_DIR`  | `/data`               | Directory inside the container to read from. |
+| `FILENAME` | `auto_code_review.md` | File name to render inside `SRC_DIR`.        |
+| `PORT`     | `3000`                | Port exposed by the Express server.          |
 
 ## Local development
 
 ```bash
 cd auto-review-viewer/app
 npm install
+# Optionally set where to read the markdown from:
 SRC_DIR=/path/to/data FILENAME=auto_code_review.md npm start
 ```
 
-The app serves the UI at [http://localhost:3000](http://localhost:3000).
+On startup, the server uses `SRC_DIR` (if provided) as the default folder for `FILENAME`. The app serves the UI at http://localhost:3000.
 
 ## Docker
 
@@ -76,10 +77,14 @@ Environment variables:
 
 ## Endpoints
 
-- `GET /` – render the Markdown file as rich HTML.
-- `GET /mtime` – return the file's last modified timestamp (`{ mtimeMs, iso }`).
-- `GET /healthz` – simple health check returning `{ status: "ok" }`.
+- `GET /` render the Markdown file as rich HTML.
+- `GET /mtime` return the file's last modified timestamp (`{ mtimeMs, iso }`).
+- `GET /healthz` simple health check returning `{ status: "ok" }`.
 
 ## Future enhancements
 
 The rendering pipeline is centralized in `server.js` so future features (BAD code annotations, diff-specific actions, WebSockets, etc.) can be layered without rewriting the core. The Docker base already includes Git to support git-aware functionality later on.
+
+## Logging
+
+By default, logs print to console only when `LOG_TO_CONSOLE=true`. File logging is optional to reduce I/O; enable it with `LOG_TO_FILE=true` (writes to `new.log`).

--- a/auto-review-viewer/README.md
+++ b/auto-review-viewer/README.md
@@ -30,6 +30,7 @@ auto-review-viewer/
 |----------- |-----------------------|----------------------------------------------|
 | `SRC_DIR`  | `/data`               | Directory inside the container to read from. |
 | `FILENAME` | `auto_code_review.md` | File name to render inside `SRC_DIR`.        |
+| `REPO_DIR` | `/data`               | Git repository root used for applying diffs. |
 | `PORT`     | `3000`                | Port exposed by the Express server.          |
 
 ## Local development
@@ -56,10 +57,14 @@ Run it, mounting the folder that contains `auto_code_review.md`:
 ```bash
 docker run --rm -p 3000:3000 \
   -e SRC_DIR=/data \
+  -e REPO_DIR=/data \
   -e FILENAME=auto_code_review.md \
   -v /absolute/path/to/markdown:/data \
   auto-review-viewer
 ```
+
+Ensure the bind mount is read/write (omit `:ro`) so `git apply` can update your local files.
+The server automatically registers the mounted repository as a Git safe directory; if you still see `dubious ownership` errors, run `git config --global --add safe.directory /data` inside the container.
 
 ## Docker Compose
 
@@ -70,10 +75,13 @@ cd auto-review-viewer
 ACR_SOURCE=/absolute/path/to/markdown docker compose up --build
 ```
 
+Ensure `ACR_SOURCE` points to the Git repository you want to modify and keep the bind mount writable so suggestion patches can land on your host. If you mount the repo somewhere else inside the container, set `ACR_REPO_DIR` to that path.
+
 Environment variables:
 
 - `ACR_SOURCE`: directory to mount at `/data` (defaults to `./data`).
 - `ACR_FILENAME`: optional override for the markdown file name.
+- `ACR_REPO_DIR`: optional container path passed to Git when applying suggestions (defaults to `/data`).
 
 ## Endpoints
 

--- a/auto-review-viewer/app/logger.js
+++ b/auto-review-viewer/app/logger.js
@@ -4,6 +4,7 @@ const path = require('path');
 const LOG_FILE_PATH = path.join(__dirname, '..', 'new.log');
 const MAX_STRING_LENGTH = 2000;
 const LOG_TO_CONSOLE = process.env.LOG_TO_CONSOLE === 'true';
+const LOG_TO_FILE = process.env.LOG_TO_FILE === 'true';
 
 function truncateString(value) {
   if (typeof value !== 'string') {
@@ -103,10 +104,12 @@ function writeLog(level, message, metadata) {
   }
   line += '\n';
 
-  fs.promises.appendFile(LOG_FILE_PATH, line).catch((error) => {
-    const consoleLine = `[${timestamp}] [ERROR] Failed to write log entry`;
-    console.error(consoleLine, sanitizeForLog(error));
-  });
+  if (LOG_TO_FILE) {
+    fs.promises.appendFile(LOG_FILE_PATH, line).catch((error) => {
+      const consoleLine = `[${timestamp}] [ERROR] Failed to write log entry`;
+      console.error(consoleLine, sanitizeForLog(error));
+    });
+  }
 
   if (level === 'ERROR') {
     const consoleLine = `[${timestamp}] [${level}] ${textMessage}`;

--- a/auto-review-viewer/app/review-utils.js
+++ b/auto-review-viewer/app/review-utils.js
@@ -199,6 +199,36 @@ function ensureTrailingNewline(text) {
   return `${text}\n`;
 }
 
+function isDubiousOwnershipError(error) {
+  if (!error) {
+    return false;
+  }
+  const stderr = typeof error.stderr === 'string' ? error.stderr.toLowerCase() : '';
+  const stdout = typeof error.stdout === 'string' ? error.stdout.toLowerCase() : '';
+  const message = typeof error.message === 'string' ? error.message.toLowerCase() : '';
+  return stderr.includes('dubious ownership') || stdout.includes('dubious ownership') || message.includes('dubious ownership');
+}
+
+async function ensureRepoIsSafe(repoDir) {
+  if (typeof repoDir !== 'string' || repoDir.trim() === '') {
+    return;
+  }
+
+  const sanitizedPath = repoDir.replace(/\\/g, '/');
+
+  try {
+    await runGitCommand(['config', '--global', '--add', 'safe.directory', sanitizedPath], process.cwd());
+    logger.logInfo('Registered git safe.directory entry for repository', {
+      repoDir: sanitizedPath
+    });
+  } catch (error) {
+    logger.logWarn('Failed to register git safe.directory entry', {
+      repoDir: sanitizedPath,
+      error
+    });
+  }
+}
+
 function runGitCommand(args, cwd, diffText) {
   return new Promise((resolve, reject) => {
     logger.logInfo('Running git command', {
@@ -278,9 +308,13 @@ async function applySuggestionDiff(diffText, repoDir) {
     diffLength: normalizedDiff.length
   });
 
+  const attemptApply = async () => {
+    await runGitCommand(['apply', '--check', '--ignore-whitespace', '--whitespace=nowarn'], repoDir, normalizedDiff);
+    return runGitCommand(['apply', '--ignore-whitespace', '--whitespace=nowarn'], repoDir, normalizedDiff);
+  };
+
   try {
-    await runGitCommand(['apply', '--check', '--whitespace=nowarn'], repoDir, normalizedDiff);
-    const result = await runGitCommand(['apply', '--whitespace=nowarn'], repoDir, normalizedDiff);
+    const result = await attemptApply();
     logger.logInfo('applySuggestionDiff succeeded', {
       repoDir,
       diffLength: normalizedDiff.length,
@@ -289,6 +323,30 @@ async function applySuggestionDiff(diffText, repoDir) {
     });
     return result;
   } catch (error) {
+    if (isDubiousOwnershipError(error)) {
+      logger.logWarn('git apply failed due to dubious ownership; retrying after registering safe.directory', {
+        repoDir,
+        error
+      });
+      await ensureRepoIsSafe(repoDir);
+      try {
+        const retryResult = await attemptApply();
+        logger.logInfo('applySuggestionDiff succeeded after registering safe.directory', {
+          repoDir,
+          diffLength: normalizedDiff.length,
+          stdout: retryResult.stdout,
+          stderr: retryResult.stderr
+        });
+        return retryResult;
+      } catch (retryError) {
+        logger.logError('Retry after registering safe.directory failed', {
+          repoDir,
+          error: retryError
+        });
+        throw retryError;
+      }
+    }
+
     logger.logError('applySuggestionDiff failed', {
       repoDir,
       error
@@ -301,4 +359,5 @@ module.exports = {
   parseBadAssessments,
   applySuggestionDiff
 };
+
 

--- a/auto-review-viewer/app/server.js
+++ b/auto-review-viewer/app/server.js
@@ -11,14 +11,13 @@ const app = express();
 app.disable('x-powered-by');
 app.use(express.json({ limit: '1mb' }));
 
-const DEFAULT_SRC_DIR = path.resolve(process.env.SRC_DIR || '/data');
 const FILENAME = process.env.FILENAME || 'auto_code_review.md';
 const PORT = Number(process.env.PORT || 3000);
 
-let currentSourceDirectory = DEFAULT_SRC_DIR;
-let targetPath = path.resolve(currentSourceDirectory, FILENAME);
+let currentSourceDirectory = null;
+let targetPath = null;
 const templatePath = path.join(__dirname, 'templates', 'index.html');
-const REPO_DIR = process.env.REPO_DIR ? path.resolve(process.env.REPO_DIR) : DEFAULT_SRC_DIR;
+const REPO_DIR = process.env.REPO_DIR ? path.resolve(process.env.REPO_DIR) : process.cwd();
 
 const md = new MarkdownIt({
   html: true,
@@ -36,24 +35,38 @@ function getReviewSource() {
   };
 }
 
+function normalizeDirectorySeparators(value) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  if (path.sep === '\\') {
+    return value.replace(/\//g, '\\');
+  }
+  return value.replace(/\\/g, '/');
+}
+
 function resolveSourceDirectory(input) {
   if (typeof input !== 'string') {
-    return DEFAULT_SRC_DIR;
+    return null;
   }
   const trimmed = input.trim();
   if (!trimmed) {
-    return DEFAULT_SRC_DIR;
+    return null;
   }
-  return path.resolve(trimmed);
+  const normalized = normalizeDirectorySeparators(trimmed);
+  return path.resolve(normalized);
 }
 
 function updateSourceDirectory(nextDirectory) {
   currentSourceDirectory = nextDirectory;
-  targetPath = path.resolve(currentSourceDirectory, FILENAME);
+  targetPath = currentSourceDirectory ? path.resolve(currentSourceDirectory, FILENAME) : null;
   return getReviewSource();
 }
 
 async function checkReviewFileExists() {
+  if (!targetPath) {
+    return false;
+  }
   try {
     await fs.promises.access(targetPath, fs.constants.R_OK);
     return true;
@@ -96,6 +109,11 @@ async function loadTemplate() {
 
 async function readMarkdownFile() {
   const { path: reviewPath } = getReviewSource();
+  if (!reviewPath) {
+    const error = new Error('Review folder not configured.');
+    error.code = 'ENOENT';
+    throw error;
+  }
   logger.logDebug('Reading markdown review file', { targetPath: reviewPath });
   const content = await fs.promises.readFile(reviewPath, 'utf8');
   logger.logDebug('Finished reading markdown review file', {
@@ -107,9 +125,10 @@ async function readMarkdownFile() {
 
 function injectTemplate(template, renderedMarkdown) {
   const { path: reviewPath } = getReviewSource();
+  const displayPath = reviewPath || 'Not configured';
   return template
     .replace(/\{\{FILE_NAME\}\}/g, FILENAME)
-    .replace(/\{\{FILE_PATH\}\}/g, reviewPath)
+    .replace(/\{\{FILE_PATH\}\}/g, displayPath)
     .replace(/\{\{CONTENT\}\}/g, renderedMarkdown);
 }
 
@@ -126,21 +145,33 @@ app.get('/', async (req, res) => {
     let markdown = '';
     let missingReviewFile = false;
 
-    try {
-      markdown = await readMarkdownFile();
-    } catch (error) {
-      if (error && error.code === 'ENOENT') {
-        missingReviewFile = true;
-        const { path: reviewPath } = getReviewSource();
-        logger.logWarn('Review markdown file not found while rendering index page', {
-          requestId,
-          reviewPath
-        });
-        markdown = `# Review file not found\n\nThe configured folder does not contain \`${FILENAME}\`.\n\n` +
-          `**Current location:** \`${reviewPath}\`\n\n` +
-          'You can update the folder path from the settings menu.';
-      } else {
-        throw error;
+    const { path: reviewPath } = getReviewSource();
+
+    if (!reviewPath) {
+      missingReviewFile = true;
+      logger.logWarn('Review folder not configured while rendering index page', {
+        requestId
+      });
+      markdown = `# Review folder not configured\n\n` +
+        `No folder has been selected for \`${FILENAME}\` yet.\n\n` +
+        'Open the settings menu and choose the folder that contains the review file.';
+    } else {
+      try {
+        markdown = await readMarkdownFile();
+      } catch (error) {
+        if (error && error.code === 'ENOENT') {
+          missingReviewFile = true;
+          logger.logWarn('Review markdown file not found while rendering index page', {
+            requestId,
+            reviewPath
+          });
+          markdown = `# Review file not found\n\n` +
+            `The selected folder does not contain \`${FILENAME}\`.\n\n` +
+            `**Current location:** \`${reviewPath}\`\n\n` +
+            'You can update the folder path from the settings menu.';
+        } else {
+          throw error;
+        }
       }
     }
 
@@ -153,11 +184,15 @@ app.get('/', async (req, res) => {
     res.send(html);
     logger.logInfo('Served index page successfully', {
       requestId,
-      missingReviewFile
+      missingReviewFile,
+      reviewPath
     });
   } catch (error) {
-    const message = error.code === 'ENOENT'
+    const missingMessage = targetPath
       ? `Could not find markdown file at ${targetPath}`
+      : 'Review folder not configured.';
+    const message = error.code === 'ENOENT'
+      ? missingMessage
       : 'Failed to render markdown file.';
     const details = error.message || 'Unknown error';
     logger.logError('Failed to serve index page', {
@@ -179,9 +214,13 @@ app.get('/api/assessments/bad', async (req, res) => {
     method: req.method
   });
   try {
+    const reviewPath = targetPath;
+    const statsPromise = reviewPath
+      ? fs.promises.stat(reviewPath).catch(() => null)
+      : Promise.resolve(null);
     const [markdown, stats] = await Promise.all([
       readMarkdownFile(),
-      fs.promises.stat(targetPath).catch(() => null)
+      statsPromise
     ]);
     const assessments = parseBadAssessments(markdown);
 
@@ -215,9 +254,12 @@ app.get('/api/assessments/bad', async (req, res) => {
       error
     });
     const status = error.code === 'ENOENT' ? 404 : 500;
+    const responseMessage = status === 404
+      ? error.message || 'Review file not found.'
+      : 'Failed to parse review file.';
     res.setHeader('Cache-Control', 'no-store, max-age=0');
     res.status(status).json({
-      error: status === 404 ? 'Review file not found.' : 'Failed to parse review file.',
+      error: responseMessage,
       details: error.message
     });
   }
@@ -300,10 +342,11 @@ app.post('/api/assessments/:id/apply', async (req, res) => {
     });
   } catch (error) {
     const status = error.code === 'ENOENT' ? 404 : error.exitCode ? 409 : 500;
+    const responseMessage = status === 404 ? (error.message || 'Review file not found.') : error.message;
     res.setHeader('Cache-Control', 'no-store, max-age=0');
     res.status(status).json({
       success: false,
-      error: status === 404 ? 'Review file not found.' : error.message,
+      error: responseMessage,
       stdout: error.stdout || '',
       stderr: error.stderr || ''
     });
@@ -386,6 +429,17 @@ app.get('/mtime', async (req, res) => {
     path: req.path
   });
   try {
+    if (!targetPath) {
+      logger.logWarn('Mtime requested without configured review folder', {
+        requestId
+      });
+      res.setHeader('Cache-Control', 'no-store, max-age=0');
+      res.status(404).json({
+        error: 'Review folder not configured.',
+        file: FILENAME
+      });
+      return;
+    }
     const stats = await fs.promises.stat(targetPath);
     logger.logInfo('Resolved mtime', {
       requestId,
@@ -424,6 +478,10 @@ app.get('/healthz', (req, res) => {
 
 function ensureSourceDirectory() {
   const { path: reviewPath } = getReviewSource();
+  if (!reviewPath) {
+    logger.logInfo('Skipping markdown source verification: no folder configured yet.');
+    return Promise.resolve();
+  }
   return fs.promises.access(reviewPath, fs.constants.R_OK)
     .then(() => {
       logger.logInfo('Verified markdown source is accessible', { targetPath: reviewPath });
@@ -447,6 +505,7 @@ async function start() {
   logger.logInfo('Starting Auto Code Review Viewer server', {
     port: PORT,
     reviewFile: reviewPath,
+    reviewFolderConfigured: Boolean(reviewPath),
     repoDirectory: REPO_DIR
   });
 
@@ -455,6 +514,7 @@ async function start() {
     logger.logInfo('Auto Code Review Viewer listening', {
       port: PORT,
       reviewFile: listenReviewPath,
+      reviewFolderConfigured: Boolean(listenReviewPath),
       repoDirectory: REPO_DIR
     });
   });

--- a/auto-review-viewer/app/server.js
+++ b/auto-review-viewer/app/server.js
@@ -15,6 +15,7 @@ const FILENAME = process.env.FILENAME || 'auto_code_review.md';
 const PORT = Number(process.env.PORT || 3000);
 
 let currentSourceDirectory = null;
+let currentSourceDirectoryInput = '';
 let targetPath = null;
 const templatePath = path.join(__dirname, 'templates', 'index.html');
 const REPO_DIR = process.env.REPO_DIR ? path.resolve(process.env.REPO_DIR) : process.cwd();
@@ -29,7 +30,7 @@ let cachedTemplate = null;
 
 function getReviewSource() {
   return {
-    directory: currentSourceDirectory,
+    directory: currentSourceDirectoryInput,
     filename: FILENAME,
     path: targetPath
   };
@@ -39,10 +40,10 @@ function normalizeDirectorySeparators(value) {
   if (typeof value !== 'string') {
     return value;
   }
-  if (path.sep === '\\') {
-    return value.replace(/\//g, '\\');
+  if (path.sep === path.win32.sep) {
+    return value.split('/').join(path.win32.sep);
   }
-  return value.replace(/\\/g, '/');
+  return value.split(path.win32.sep).join('/');
 }
 
 function resolveSourceDirectory(input) {
@@ -57,8 +58,13 @@ function resolveSourceDirectory(input) {
   return path.resolve(normalized);
 }
 
-function updateSourceDirectory(nextDirectory) {
+function updateSourceDirectory(nextDirectory, rawInput) {
   currentSourceDirectory = nextDirectory;
+  if (typeof rawInput === 'string') {
+    currentSourceDirectoryInput = rawInput;
+  } else if (!nextDirectory) {
+    currentSourceDirectoryInput = '';
+  }
   targetPath = currentSourceDirectory ? path.resolve(currentSourceDirectory, FILENAME) : null;
   return getReviewSource();
 }
@@ -124,8 +130,8 @@ async function readMarkdownFile() {
 }
 
 function injectTemplate(template, renderedMarkdown) {
-  const { path: reviewPath } = getReviewSource();
-  const displayPath = reviewPath || 'Not configured';
+  const { path: reviewPath, directory } = getReviewSource();
+  const displayPath = directory || reviewPath || 'Not configured';
   return template
     .replace(/\{\{FILE_NAME\}\}/g, FILENAME)
     .replace(/\{\{FILE_PATH\}\}/g, displayPath)
@@ -401,6 +407,8 @@ app.get('/api/review-source', async (req, res) => {
 app.post('/api/review-source', async (req, res) => {
   const requestId = createRequestId();
   const rawDirectory = typeof req.body?.directory === 'string' ? req.body.directory : '';
+  const trimmedDirectory = rawDirectory.trim();
+  const normalizedInput = trimmedDirectory ? normalizeDirectorySeparators(trimmedDirectory) : '';
   const resolvedDirectory = resolveSourceDirectory(rawDirectory);
   const previous = getReviewSource();
 
@@ -408,10 +416,11 @@ app.post('/api/review-source', async (req, res) => {
     requestId,
     previousDirectory: previous.directory,
     requestedDirectory: rawDirectory,
+    normalizedDirectory: normalizedInput,
     resolvedDirectory
   });
 
-  const updated = updateSourceDirectory(resolvedDirectory);
+  const updated = updateSourceDirectory(resolvedDirectory, normalizedInput);
   const exists = await checkReviewFileExists();
 
   res.setHeader('Cache-Control', 'no-store, max-age=0');

--- a/auto-review-viewer/app/server.js
+++ b/auto-review-viewer/app/server.js
@@ -11,13 +11,14 @@ const app = express();
 app.disable('x-powered-by');
 app.use(express.json({ limit: '1mb' }));
 
-const SRC_DIR = path.resolve(process.env.SRC_DIR || '/data');
+const DEFAULT_SRC_DIR = path.resolve(process.env.SRC_DIR || '/data');
 const FILENAME = process.env.FILENAME || 'auto_code_review.md';
 const PORT = Number(process.env.PORT || 3000);
 
-const targetPath = path.resolve(SRC_DIR, FILENAME);
+let currentSourceDirectory = DEFAULT_SRC_DIR;
+let targetPath = path.resolve(currentSourceDirectory, FILENAME);
 const templatePath = path.join(__dirname, 'templates', 'index.html');
-const REPO_DIR = process.env.REPO_DIR ? path.resolve(process.env.REPO_DIR) : SRC_DIR;
+const REPO_DIR = process.env.REPO_DIR ? path.resolve(process.env.REPO_DIR) : DEFAULT_SRC_DIR;
 
 const md = new MarkdownIt({
   html: true,
@@ -26,6 +27,46 @@ const md = new MarkdownIt({
 });
 
 let cachedTemplate = null;
+
+function getReviewSource() {
+  return {
+    directory: currentSourceDirectory,
+    filename: FILENAME,
+    path: targetPath
+  };
+}
+
+function resolveSourceDirectory(input) {
+  if (typeof input !== 'string') {
+    return DEFAULT_SRC_DIR;
+  }
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return DEFAULT_SRC_DIR;
+  }
+  return path.resolve(trimmed);
+}
+
+function updateSourceDirectory(nextDirectory) {
+  currentSourceDirectory = nextDirectory;
+  targetPath = path.resolve(currentSourceDirectory, FILENAME);
+  return getReviewSource();
+}
+
+async function checkReviewFileExists() {
+  try {
+    await fs.promises.access(targetPath, fs.constants.R_OK);
+    return true;
+  } catch (error) {
+    if (error && error.code !== 'ENOENT') {
+      logger.logWarn('Failed to access review file during existence check', {
+        error,
+        targetPath
+      });
+    }
+    return false;
+  }
+}
 
 function createRequestId() {
   if (typeof randomUUID === 'function') {
@@ -54,19 +95,21 @@ async function loadTemplate() {
 }
 
 async function readMarkdownFile() {
-  logger.logDebug('Reading markdown review file', { targetPath });
-  const content = await fs.promises.readFile(targetPath, 'utf8');
+  const { path: reviewPath } = getReviewSource();
+  logger.logDebug('Reading markdown review file', { targetPath: reviewPath });
+  const content = await fs.promises.readFile(reviewPath, 'utf8');
   logger.logDebug('Finished reading markdown review file', {
-    targetPath,
+    targetPath: reviewPath,
     bytes: content.length
   });
   return content;
 }
 
 function injectTemplate(template, renderedMarkdown) {
+  const { path: reviewPath } = getReviewSource();
   return template
     .replace(/\{\{FILE_NAME\}\}/g, FILENAME)
-    .replace(/\{\{FILE_PATH\}\}/g, targetPath)
+    .replace(/\{\{FILE_PATH\}\}/g, reviewPath)
     .replace(/\{\{CONTENT\}\}/g, renderedMarkdown);
 }
 
@@ -79,17 +122,39 @@ app.get('/', async (req, res) => {
     ip: req.ip
   });
   try {
-    const [template, markdown] = await Promise.all([
-      loadTemplate(),
-      readMarkdownFile()
-    ]);
+    const templatePromise = loadTemplate();
+    let markdown = '';
+    let missingReviewFile = false;
+
+    try {
+      markdown = await readMarkdownFile();
+    } catch (error) {
+      if (error && error.code === 'ENOENT') {
+        missingReviewFile = true;
+        const { path: reviewPath } = getReviewSource();
+        logger.logWarn('Review markdown file not found while rendering index page', {
+          requestId,
+          reviewPath
+        });
+        markdown = `# Review file not found\n\nThe configured folder does not contain \`${FILENAME}\`.\n\n` +
+          `**Current location:** \`${reviewPath}\`\n\n` +
+          'You can update the folder path from the settings menu.';
+      } else {
+        throw error;
+      }
+    }
+
+    const template = await templatePromise;
     const rendered = md.render(markdown);
     const html = injectTemplate(template, rendered);
 
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     res.setHeader('Cache-Control', 'no-store, must-revalidate');
     res.send(html);
-    logger.logInfo('Served index page successfully', { requestId });
+    logger.logInfo('Served index page successfully', {
+      requestId,
+      missingReviewFile
+    });
   } catch (error) {
     const message = error.code === 'ENOENT'
       ? `Could not find markdown file at ${targetPath}`
@@ -272,6 +337,47 @@ app.post('/api/logs', (req, res) => {
   res.status(204).end();
 });
 
+app.get('/api/review-source', async (req, res) => {
+  const requestId = createRequestId();
+  logger.logInfo('Received request for review source information', {
+    requestId,
+    method: req.method,
+    path: req.path
+  });
+
+  const exists = await checkReviewFileExists();
+  const source = getReviewSource();
+
+  res.setHeader('Cache-Control', 'no-store, max-age=0');
+  res.json({
+    ...source,
+    exists
+  });
+});
+
+app.post('/api/review-source', async (req, res) => {
+  const requestId = createRequestId();
+  const rawDirectory = typeof req.body?.directory === 'string' ? req.body.directory : '';
+  const resolvedDirectory = resolveSourceDirectory(rawDirectory);
+  const previous = getReviewSource();
+
+  logger.logInfo('Received request to update review source directory', {
+    requestId,
+    previousDirectory: previous.directory,
+    requestedDirectory: rawDirectory,
+    resolvedDirectory
+  });
+
+  const updated = updateSourceDirectory(resolvedDirectory);
+  const exists = await checkReviewFileExists();
+
+  res.setHeader('Cache-Control', 'no-store, max-age=0');
+  res.json({
+    ...updated,
+    exists
+  });
+});
+
 app.get('/mtime', async (req, res) => {
   const requestId = createRequestId();
   logger.logDebug('Received mtime request', {
@@ -317,16 +423,17 @@ app.get('/healthz', (req, res) => {
 });
 
 function ensureSourceDirectory() {
-  return fs.promises.access(targetPath, fs.constants.R_OK)
+  const { path: reviewPath } = getReviewSource();
+  return fs.promises.access(reviewPath, fs.constants.R_OK)
     .then(() => {
-      logger.logInfo('Verified markdown source is accessible', { targetPath });
+      logger.logInfo('Verified markdown source is accessible', { targetPath: reviewPath });
     })
     .catch((error) => {
       const message = error.code === 'ENOENT'
-        ? `Markdown file not found at ${targetPath}`
-        : `Cannot read markdown file at ${targetPath}: ${error.message}`;
+        ? `Markdown file not found at ${reviewPath}`
+        : `Cannot read markdown file at ${reviewPath}: ${error.message}`;
       logger.logError('Failed to verify markdown source', {
-        targetPath,
+        targetPath: reviewPath,
         error,
         message
       });
@@ -336,16 +443,18 @@ function ensureSourceDirectory() {
 async function start() {
   await ensureSourceDirectory();
 
+  const { path: reviewPath } = getReviewSource();
   logger.logInfo('Starting Auto Code Review Viewer server', {
     port: PORT,
-    reviewFile: targetPath,
+    reviewFile: reviewPath,
     repoDirectory: REPO_DIR
   });
 
   app.listen(PORT, () => {
+    const { path: listenReviewPath } = getReviewSource();
     logger.logInfo('Auto Code Review Viewer listening', {
       port: PORT,
-      reviewFile: targetPath,
+      reviewFile: listenReviewPath,
       repoDirectory: REPO_DIR
     });
   });

--- a/auto-review-viewer/app/server.js
+++ b/auto-review-viewer/app/server.js
@@ -18,7 +18,11 @@ let currentSourceDirectory = null;
 let currentSourceDirectoryInput = '';
 let targetPath = null;
 const templatePath = path.join(__dirname, 'templates', 'index.html');
-const REPO_DIR = process.env.REPO_DIR ? path.resolve(process.env.REPO_DIR) : process.cwd();
+const rawRepoDirEnv = typeof process.env.REPO_DIR === 'string' ? process.env.REPO_DIR.trim() : '';
+const rawSourceDirEnv = typeof process.env.SRC_DIR === 'string' ? process.env.SRC_DIR.trim() : '';
+const repoDirCandidate = rawRepoDirEnv || rawSourceDirEnv;
+const normalizedRepoDir = repoDirCandidate ? normalizeDirectorySeparators(repoDirCandidate) : '';
+const REPO_DIR = normalizedRepoDir ? path.resolve(normalizedRepoDir) : process.cwd();
 
 const md = new MarkdownIt({
   html: true,
@@ -67,6 +71,17 @@ function updateSourceDirectory(nextDirectory, rawInput) {
   }
   targetPath = currentSourceDirectory ? path.resolve(currentSourceDirectory, FILENAME) : null;
   return getReviewSource();
+}
+
+const initialSourceDirectoryEnv = rawSourceDirEnv;
+if (initialSourceDirectoryEnv) {
+  const normalizedInitialSourceInput = normalizeDirectorySeparators(initialSourceDirectoryEnv);
+  const resolvedInitialSourceDirectory = resolveSourceDirectory(initialSourceDirectoryEnv);
+  const initializedSource = updateSourceDirectory(resolvedInitialSourceDirectory, normalizedInitialSourceInput);
+  logger.logInfo('Initialized review source directory from environment', {
+    configuredDirectory: initializedSource.directory,
+    resolvedPath: initializedSource.path
+  });
 }
 
 async function checkReviewFileExists() {

--- a/auto-review-viewer/app/templates/index.html
+++ b/auto-review-viewer/app/templates/index.html
@@ -196,6 +196,44 @@
                       <option value="relaxed">Relaxed</option>
                     </select>
                   </div>
+                  <form
+                    id="review-directory-form"
+                    class="space-y-2 border-t border-slate-200 pt-3 dark:border-slate-700"
+                  >
+                    <div>
+                      <label
+                        for="review-directory-input"
+                        class="block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+                      >
+                        Review folder
+                      </label>
+                      <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                        Choose the folder that contains <span class="font-semibold text-slate-700 dark:text-slate-200">{{FILE_NAME}}</span>.
+                      </p>
+                    </div>
+                    <div class="flex items-center gap-2">
+                      <input
+                        id="review-directory-input"
+                        name="review-directory"
+                        type="text"
+                        autocomplete="off"
+                        spellcheck="false"
+                        class="flex-1 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                        placeholder="/path/to/folder"
+                      />
+                      <button
+                        id="review-directory-submit"
+                        type="submit"
+                        class="inline-flex items-center gap-2 rounded-full border border-brand-500 bg-brand-500 px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-brand-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        Update
+                      </button>
+                    </div>
+                    <p
+                      id="review-directory-status"
+                      class="text-xs text-slate-500 dark:text-slate-400"
+                    ></p>
+                  </form>
                 </div>
               </div>
             </div>
@@ -403,6 +441,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-b8qFkC4bIZfv5Ih0b07XHkTTwxabycufV7g9cMPed+0YLsFd1oS29Jym+wIpLW6+BFmGoG9PMa2wiuVdbTNjlQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/diff.min.js" integrity="sha512-f9GtPgNj0JfnYuxzsDgVKfd3RewZF8nPULz/0NkGi/Sd35rEJMMHSdOQcgynb43S/G/Sq0yYMpnt/kFBTw+Fxg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script>
+      const reviewFileName = '{{FILE_NAME}}';
       const themeToggle = document.getElementById('theme-toggle');
       const statusLine = document.getElementById('status-line');
       const themeToggleLabel = document.getElementById('theme-toggle-label');
@@ -438,6 +477,12 @@
       const actionHelpPanel = document.getElementById('action-help-panel');
       const actionHelpClose = document.getElementById('action-help-close');
       const modeToggleButtons = document.querySelectorAll('[data-viewer-mode]');
+      const reviewDirectoryForm = document.getElementById('review-directory-form');
+      const reviewDirectoryInput = document.getElementById('review-directory-input');
+      const reviewDirectoryStatus = document.getElementById('review-directory-status');
+      const reviewDirectorySubmit = document.getElementById('review-directory-submit');
+
+      let reviewSourceInfo = null;
 
       const FONT_SIZE_OPTIONS = {
         sm: '0.875rem',
@@ -481,6 +526,22 @@
         info: ['border-slate-300', 'bg-slate-100', 'text-slate-700', 'dark:border-slate-600', 'dark:bg-slate-800', 'dark:text-slate-200']
       };
       const ALL_FEEDBACK_CLASSES = Array.from(new Set(Object.values(FEEDBACK_CLASS_MAP).flat()));
+
+      const REVIEW_DIRECTORY_STATUS_CLASS_MAP = {
+        neutral: ['text-slate-500', 'dark:text-slate-400'],
+        success: ['text-emerald-600', 'dark:text-emerald-300'],
+        error: ['text-rose-600', 'dark:text-rose-300']
+      };
+      const REVIEW_DIRECTORY_STATUS_CLASSES = Array.from(
+        new Set(Object.values(REVIEW_DIRECTORY_STATUS_CLASS_MAP).flat())
+      );
+
+      const STATUS_LINE_CLASS_MAP = {
+        neutral: ['text-slate-500', 'dark:text-slate-400'],
+        warning: ['text-amber-500'],
+        error: ['text-red-500']
+      };
+      const STATUS_LINE_CLASSES = Array.from(new Set(Object.values(STATUS_LINE_CLASS_MAP).flat()));
 
       const actionState = {
         loading: false,
@@ -609,6 +670,12 @@
         }
       });
 
+      reviewDirectoryForm?.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const value = reviewDirectoryInput ? reviewDirectoryInput.value : '';
+        submitReviewDirectoryUpdate(value);
+      });
+
       function setSettingsPanelVisibility(visible) {
         if (!settingsPanel || !settingsToggle) return;
         if (visible) {
@@ -680,6 +747,124 @@
         classes.forEach((cls) => actionFeedback.classList.add(cls));
         actionFeedback.textContent = message;
         actionFeedback.classList.remove('hidden');
+      }
+
+      function setStatusLine(message, tone = 'neutral') {
+        if (!statusLine) {
+          return;
+        }
+        statusLine.textContent = message;
+        STATUS_LINE_CLASSES.forEach((cls) => statusLine.classList.remove(cls));
+        const classes = STATUS_LINE_CLASS_MAP[tone] || STATUS_LINE_CLASS_MAP.neutral;
+        classes.forEach((cls) => statusLine.classList.add(cls));
+      }
+
+      function setReviewDirectoryStatus(message, tone = 'neutral') {
+        if (!reviewDirectoryStatus) {
+          return;
+        }
+        reviewDirectoryStatus.textContent = message;
+        REVIEW_DIRECTORY_STATUS_CLASSES.forEach((cls) => reviewDirectoryStatus.classList.remove(cls));
+        const classes =
+          REVIEW_DIRECTORY_STATUS_CLASS_MAP[tone] || REVIEW_DIRECTORY_STATUS_CLASS_MAP.neutral;
+        classes.forEach((cls) => reviewDirectoryStatus.classList.add(cls));
+      }
+
+      function formatDirectoryLabel(directory) {
+        if (typeof directory !== 'string') {
+          return 'the default folder';
+        }
+        const trimmed = directory.trim();
+        return trimmed ? trimmed : 'the default folder';
+      }
+
+      async function loadReviewSource(options = {}) {
+        if (!reviewDirectoryInput && !reviewDirectoryStatus) {
+          return;
+        }
+        if (options.showLoading) {
+          setReviewDirectoryStatus('Loading folder details…', 'neutral');
+        }
+        try {
+          const response = await fetch('/api/review-source', { cache: 'no-store' });
+          if (!response.ok) {
+            throw new Error(`Request failed with status ${response.status}`);
+          }
+          const data = await response.json();
+          reviewSourceInfo = data;
+          if (reviewDirectoryInput && typeof data.directory === 'string') {
+            reviewDirectoryInput.value = data.directory;
+          }
+          const directoryLabel = formatDirectoryLabel(data.directory);
+          if (data.exists) {
+            setReviewDirectoryStatus(
+              `Looking for ${reviewFileName} in ${directoryLabel}.`,
+              'neutral'
+            );
+            setStatusLine(`Watching for changes in ${directoryLabel}…`, 'neutral');
+          } else {
+            setReviewDirectoryStatus(
+              `${reviewFileName} not found in ${directoryLabel}.`,
+              'error'
+            );
+            setStatusLine(`Waiting for ${reviewFileName} in ${directoryLabel}…`, 'warning');
+          }
+        } catch (error) {
+          console.error('Failed to load review source information', error);
+          setReviewDirectoryStatus('Unable to load review folder details.', 'error');
+          setStatusLine('Unable to load review folder details.', 'error');
+        }
+      }
+
+      async function submitReviewDirectoryUpdate(directoryValue) {
+        const payloadDirectory = typeof directoryValue === 'string' ? directoryValue.trim() : '';
+        if (reviewDirectorySubmit) {
+          reviewDirectorySubmit.disabled = true;
+        }
+        setReviewDirectoryStatus('Saving folder…', 'neutral');
+        try {
+          const response = await fetch('/api/review-source', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ directory: payloadDirectory })
+          });
+          if (!response.ok) {
+            throw new Error(`Request failed with status ${response.status}`);
+          }
+          const data = await response.json();
+          reviewSourceInfo = data;
+          if (reviewDirectoryInput && typeof data.directory === 'string') {
+            reviewDirectoryInput.value = data.directory;
+          }
+          const directoryLabel = formatDirectoryLabel(data.directory);
+          if (data.exists) {
+            setReviewDirectoryStatus(
+              `Found ${reviewFileName} in ${directoryLabel}. Reloading…`,
+              'success'
+            );
+            setStatusLine(
+              `Reloading to show ${reviewFileName} from ${directoryLabel}…`,
+              'neutral'
+            );
+            window.setTimeout(() => {
+              window.location.reload();
+            }, 400);
+          } else {
+            setReviewDirectoryStatus(
+              `${reviewFileName} not found in ${directoryLabel}.`,
+              'error'
+            );
+            setStatusLine(`Waiting for ${reviewFileName} in ${directoryLabel}…`, 'warning');
+          }
+        } catch (error) {
+          console.error('Failed to update review folder', error);
+          setReviewDirectoryStatus('Failed to update review folder.', 'error');
+          setStatusLine('Failed to update review folder.', 'error');
+        } finally {
+          if (reviewDirectorySubmit) {
+            reviewDirectorySubmit.disabled = false;
+          }
+        }
       }
 
       function updateModeButtons(mode) {
@@ -1280,6 +1465,8 @@
 
       document.addEventListener('keydown', handleActionHotkeys);
 
+      loadReviewSource({ showLoading: true });
+
       setViewerMode(getStoredMode(), { skipStorage: true });
 
       function applyHighlightTheme(mode) {
@@ -1337,6 +1524,19 @@
       async function pollMtime() {
         try {
           const response = await fetch('/mtime', { cache: 'no-store' });
+          if (response.status === 404) {
+            polling = true;
+            if (reviewSourceInfo) {
+              reviewSourceInfo.exists = false;
+            }
+            const directoryLabel = formatDirectoryLabel(reviewSourceInfo?.directory);
+            setReviewDirectoryStatus(
+              `${reviewFileName} not found in ${directoryLabel}.`,
+              'error'
+            );
+            setStatusLine(`Waiting for ${reviewFileName} in ${directoryLabel}…`, 'warning');
+            return;
+          }
           if (!response.ok) {
             throw new Error(`Request failed with status ${response.status}`);
           }
@@ -1347,20 +1547,20 @@
               return;
             }
             lastSeenMtime = payload.mtimeMs;
-            if (statusLine) {
-              statusLine.textContent = `Watching… Last updated ${formatTimestamp(payload.mtimeMs)}`;
-              statusLine.classList.remove('text-red-500');
-              statusLine.classList.add('text-slate-500', 'dark:text-slate-400');
+            if (reviewSourceInfo) {
+              reviewSourceInfo.exists = true;
             }
+            const directoryLabel = formatDirectoryLabel(reviewSourceInfo?.directory);
+            setReviewDirectoryStatus(
+              `Looking for ${reviewFileName} in ${directoryLabel}.`,
+              'neutral'
+            );
+            setStatusLine(`Watching… Last updated ${formatTimestamp(payload.mtimeMs)}`, 'neutral');
           }
           polling = true;
         } catch (error) {
           polling = false;
-          if (statusLine) {
-            statusLine.textContent = 'Disconnected. Retrying…';
-            statusLine.classList.remove('text-slate-500', 'dark:text-slate-400');
-            statusLine.classList.add('text-red-500');
-          }
+          setStatusLine('Disconnected. Retrying…', 'error');
           console.error('Failed to poll /mtime', error);
         } finally {
           setTimeout(pollMtime, polling ? 2000 : 4000);

--- a/auto-review-viewer/app/templates/index.html
+++ b/auto-review-viewer/app/templates/index.html
@@ -530,6 +530,7 @@
       const REVIEW_DIRECTORY_STATUS_CLASS_MAP = {
         neutral: ['text-slate-500', 'dark:text-slate-400'],
         success: ['text-emerald-600', 'dark:text-emerald-300'],
+        warning: ['text-amber-600', 'dark:text-amber-300'],
         error: ['text-rose-600', 'dark:text-rose-300']
       };
       const REVIEW_DIRECTORY_STATUS_CLASSES = Array.from(
@@ -770,12 +771,15 @@
         classes.forEach((cls) => reviewDirectoryStatus.classList.add(cls));
       }
 
+      function isDirectoryConfigured(directory) {
+        return typeof directory === 'string' && directory.trim() !== '';
+      }
+
       function formatDirectoryLabel(directory) {
-        if (typeof directory !== 'string') {
-          return 'the default folder';
+        if (!isDirectoryConfigured(directory)) {
+          return '';
         }
-        const trimmed = directory.trim();
-        return trimmed ? trimmed : 'the default folder';
+        return directory.trim();
       }
 
       async function loadReviewSource(options = {}) {
@@ -792,20 +796,28 @@
           }
           const data = await response.json();
           reviewSourceInfo = data;
-          if (reviewDirectoryInput && typeof data.directory === 'string') {
-            reviewDirectoryInput.value = data.directory;
+          const hasDirectory = isDirectoryConfigured(data.directory);
+          if (reviewDirectoryInput) {
+            reviewDirectoryInput.value = hasDirectory ? data.directory : '';
           }
-          const directoryLabel = formatDirectoryLabel(data.directory);
-          if (data.exists) {
+          if (!hasDirectory) {
+            setReviewDirectoryStatus(
+              `Enter a folder path to load ${reviewFileName}.`,
+              'warning'
+            );
+            setStatusLine('Waiting for a folder selection…', 'warning');
+          } else if (data.exists) {
+            const directoryLabel = formatDirectoryLabel(data.directory);
             setReviewDirectoryStatus(
               `Looking for ${reviewFileName} in ${directoryLabel}.`,
               'neutral'
             );
             setStatusLine(`Watching for changes in ${directoryLabel}…`, 'neutral');
           } else {
+            const directoryLabel = formatDirectoryLabel(data.directory);
             setReviewDirectoryStatus(
               `${reviewFileName} not found in ${directoryLabel}.`,
-              'error'
+              'warning'
             );
             setStatusLine(`Waiting for ${reviewFileName} in ${directoryLabel}…`, 'warning');
           }
@@ -833,11 +845,18 @@
           }
           const data = await response.json();
           reviewSourceInfo = data;
-          if (reviewDirectoryInput && typeof data.directory === 'string') {
-            reviewDirectoryInput.value = data.directory;
+          const hasDirectory = isDirectoryConfigured(data.directory);
+          if (reviewDirectoryInput) {
+            reviewDirectoryInput.value = hasDirectory ? data.directory : '';
           }
-          const directoryLabel = formatDirectoryLabel(data.directory);
-          if (data.exists) {
+          if (!hasDirectory) {
+            setReviewDirectoryStatus(
+              `Enter a folder path to load ${reviewFileName}.`,
+              'warning'
+            );
+            setStatusLine('Waiting for a folder selection…', 'warning');
+          } else if (data.exists) {
+            const directoryLabel = formatDirectoryLabel(data.directory);
             setReviewDirectoryStatus(
               `Found ${reviewFileName} in ${directoryLabel}. Reloading…`,
               'success'
@@ -850,9 +869,10 @@
               window.location.reload();
             }, 400);
           } else {
+            const directoryLabel = formatDirectoryLabel(data.directory);
             setReviewDirectoryStatus(
               `${reviewFileName} not found in ${directoryLabel}.`,
-              'error'
+              'warning'
             );
             setStatusLine(`Waiting for ${reviewFileName} in ${directoryLabel}…`, 'warning');
           }
@@ -1529,12 +1549,22 @@
             if (reviewSourceInfo) {
               reviewSourceInfo.exists = false;
             }
-            const directoryLabel = formatDirectoryLabel(reviewSourceInfo?.directory);
-            setReviewDirectoryStatus(
-              `${reviewFileName} not found in ${directoryLabel}.`,
-              'error'
-            );
-            setStatusLine(`Waiting for ${reviewFileName} in ${directoryLabel}…`, 'warning');
+            const directory = reviewSourceInfo?.directory;
+            const hasDirectory = isDirectoryConfigured(directory);
+            if (!hasDirectory) {
+              setReviewDirectoryStatus(
+                `Enter a folder path to load ${reviewFileName}.`,
+                'warning'
+              );
+              setStatusLine('Waiting for a folder selection…', 'warning');
+            } else {
+              const directoryLabel = formatDirectoryLabel(directory);
+              setReviewDirectoryStatus(
+                `${reviewFileName} not found in ${directoryLabel}.`,
+                'warning'
+              );
+              setStatusLine(`Waiting for ${reviewFileName} in ${directoryLabel}…`, 'warning');
+            }
             return;
           }
           if (!response.ok) {
@@ -1550,12 +1580,21 @@
             if (reviewSourceInfo) {
               reviewSourceInfo.exists = true;
             }
-            const directoryLabel = formatDirectoryLabel(reviewSourceInfo?.directory);
-            setReviewDirectoryStatus(
-              `Looking for ${reviewFileName} in ${directoryLabel}.`,
-              'neutral'
-            );
-            setStatusLine(`Watching… Last updated ${formatTimestamp(payload.mtimeMs)}`, 'neutral');
+            const directory = reviewSourceInfo?.directory;
+            if (isDirectoryConfigured(directory)) {
+              const directoryLabel = formatDirectoryLabel(directory);
+              setReviewDirectoryStatus(
+                `Looking for ${reviewFileName} in ${directoryLabel}.`,
+                'neutral'
+              );
+              setStatusLine(`Watching… Last updated ${formatTimestamp(payload.mtimeMs)}`, 'neutral');
+            } else {
+              setReviewDirectoryStatus(
+                `Watching for updates to ${reviewFileName}.`,
+                'neutral'
+              );
+              setStatusLine(`Watching… Last updated ${formatTimestamp(payload.mtimeMs)}`, 'neutral');
+            }
           }
           polling = true;
         } catch (error) {

--- a/auto-review-viewer/docker-compose.yml
+++ b/auto-review-viewer/docker-compose.yml
@@ -6,8 +6,9 @@ services:
     environment:
       - SRC_DIR=/data
       - FILENAME=${ACR_FILENAME:-auto_code_review.md}
+      - REPO_DIR=${ACR_REPO_DIR:-/data}
     volumes:
-      - ${ACR_SOURCE:-./data}:/data:ro
+      - ${ACR_SOURCE:-./data}:/data
     develop:
       watch:
         - action: sync

--- a/auto_code_review.md
+++ b/auto_code_review.md
@@ -1,0 +1,142 @@
+<!-- code_review_formatting formatting rules:
+- Strip AI-internal cues such as "(if 'BAD')" or "(if 'GOOD')" from labels.
+- Remove prompt artefacts like the repeating-structure markers or the `**critical:**` hint.
+- Normalise whitespace (Unix line endings, collapse excessive blank lines, ensure trailing newline).
+- Rewrite `diff` code fences into git-apply-friendly patches by adding `---/+++` headers using the reported file path.
+- Synthesise `@@` hunk headers from the reported line range when they are missing so the diff is structured.
+-->
+## Overview
+The submitted changes introduce optional file-based logging, enhance the user interface by displaying a more user-friendly source path, and update documentation. While the intent is good, the execution has flaws. The logging documentation is inaccurate, a logical bug in state management could lead to UI inconsistencies, and a string utility function is implemented suboptimally. These issues reduce the code's readiness for production.  
+
+---
+
+## Change-by-Change Review
+
+### Assessment of the change: BAD
+**title:** Inaccurate Logging Documentation  
+**file:** auto-review-viewer/README.md  
+**function:** N/A  
+**Lines:** 90-92  
+**Details:** The new "Logging" section incorrectly states, "By default, logs print to console only when `LOG_TO_CONSOLE=true`." The implementation in `logger.js` unconditionally prints logs of level `ERROR` and `WARN` to the console. The `LOG_TO_CONSOLE` variable only affects `INFO` and `DEBUG` levels. This discrepancy makes the documentation misleading.  
+**Suggestion:**
+```diff
+--- a/auto-review-viewer/README.md
++++ b/auto-review-viewer/README.md
+@@ -89,4 +89,4 @@
+ ## Logging
+ 
+-By default, logs print to console only when `LOG_TO_CONSOLE=true`. File logging is optional to reduce I/O; enable it with `LOG_TO_FILE=true` (writes to `new.log`).
++Logs of level `ERROR` and `WARN` are always printed to the console. Other levels are only printed when `LOG_TO_CONSOLE=true`. File logging is optional to reduce I/O; enable it with `LOG_TO_FILE=true` (writes to `new.log`).
+```
+  
+**Reasoning:** Documentation must precisely match the implementation to prevent configuration errors and confusion during operation or debugging.  
+
+---
+
+### Assessment of the change: BAD
+**title:** Flawed State Update Logic  
+**file:** auto-review-viewer/app/server.js  
+**function:** updateSourceDirectory  
+**Lines:** 78-84  
+**Details:** The logic for updating `currentSourceDirectoryInput` is flawed. In the scenario where `rawInput` is not a string (e.g., `null`) but `nextDirectory` is a valid path, `currentSourceDirectory` is updated, but `currentSourceDirectoryInput` is not. This creates a state inconsistency, where the application uses a new path internally while the UI continues to display the old one.  
+**Suggestion:**
+```diff
+--- a/auto-review-viewer/app/server.js
++++ b/auto-review-viewer/app/server.js
+@@ -79,9 +79,9 @@
+ function updateSourceDirectory(nextDirectory, rawInput) {
+   currentSourceDirectory = nextDirectory;
+   if (typeof rawInput === 'string') {
+     currentSourceDirectoryInput = rawInput;
+-  } else if (!nextDirectory) {
++  } else {
+     currentSourceDirectoryInput = '';
+   }
+   targetPath = currentSourceDirectory ? path.resolve(currentSourceDirectory, FILENAME) : null;
+   return getReviewSource();
+```
+  
+**Reasoning:** Changing `else if` to a simple `else` ensures that `currentSourceDirectoryInput` is reliably reset when a raw input string isn't provided, preventing a state mismatch between the application's backend and frontend.  
+
+---
+
+### Assessment of the change: BAD
+**title:** Suboptimal String Replacement Implementation  
+**file:** auto-review-viewer/app/server.js  
+**function:** normalizeDirectorySeparators  
+**Lines:** 63-69  
+**Details:** The function uses `split()` and `join()` to replace path separators. The more idiomatic and generally performant approach for global string replacement in JavaScript is to use `String.prototype.replace()` with a regular expression.  
+**Suggestion:**
+```diff
+--- a/auto-review-viewer/app/server.js
++++ b/auto-review-viewer/app/server.js
+@@ -64,8 +64,8 @@
+     return value;
+   }
+   if (path.sep === path.win32.sep) {
+-    return value.split('/').join(path.win32.sep);
++    return value.replace(/\//g, path.win32.sep);
+   }
+-  return value.split(path.win32.sep).join('/');
++  return value.replace(/\\/g, '/');
+ }
+```
+  
+**Reasoning:** Adhering to common idioms like using `replace()` with a global regex for string substitution improves code quality, readability, and performance.  
+
+---
+
+### Assessment of the change: GOOD
+**title:** Add Optional File Logging  
+**file:** auto-review-viewer/app/logger.js  
+**function:** writeLog  
+**Lines:** 5, 120-125  
+**Details:** The change to make file logging conditional based on the `LOG_TO_FILE` environment variable is a good enhancement for controlling I/O.  
+
+---
+
+### Assessment of the change: GOOD
+**title:** Improved UI Path Display  
+**file:** auto-review-viewer/app/server.js  
+**function:** getReviewSource, injectTemplate  
+**Lines:** 55, 160-162  
+**Details:** Storing and displaying the user-provided path string instead of the fully resolved absolute path is a significant improvement for user experience.  
+
+---
+
+### Assessment of the change: NEUTRAL
+**title:** Add Empty Markdown File for Testing  
+**file:** auto_code_review.md  
+**function:** N/A  
+**Lines:** N/A  
+**Details:** The addition of an empty `auto_code_review.md` file is presumed to be for local development or testing purposes and has no functional impact on the application itself.  
+
+---
+
+## Potential General/Design Improvements
+The application's state is managed through several module-level variables (`currentSourceDirectory`, `currentSourceDirectoryInput`, `targetPath`). For a small service this is acceptable, but as complexity grows, this pattern can lead to maintainability issues. Consider encapsulating all related state into a single configuration object or class to make data flow more explicit and easier to reason about.  
+
+---
+
+## memory files read
+memory_template.txt - N/A  
+
+---
+
+---
+## Flake8
+- **.\scripts\code_review_formatting.py** (Line: 42, Col: 80) - `E501`: line too long (84 > 79 characters)
+- **.\scripts\code_review_formatting.py** (Line: 43, Col: 80) - `E501`: line too long (96 > 79 characters)
+- **.\scripts\code_review_formatting.py** (Line: 44, Col: 80) - `E501`: line too long (105 > 79 characters)
+- **.\scripts\code_review_formatting.py** (Line: 45, Col: 80) - `E501`: line too long (123 > 79 characters)
+- **.\scripts\code_review_formatting.py** (Line: 46, Col: 80) - `E501`: line too long (113 > 79 characters)
+- **.\scripts\code_review_formatting.py** (Line: 49, Col: 80) - `E501`: line too long (89 > 79 characters)
+- **.\scripts\code_review_formatting.py** (Line: 55, Col: 80) - `E501`: line too long (94 > 79 characters)
+- **.\scripts\code_review_formatting.py** (Line: 56, Col: 80) - `E501`: line too long (106 > 79 characters)
+- **.\scripts\code_review_formatting.py** (Line: 212, Col: 80) - `E501`: line too long (84 > 79 characters)
+- **.\scripts\code_review_formatting.py** (Line: 221, Col: 80) - `E501`: line too long (82 > 79 characters)
+- **.\scripts\code_review_formatting.py** (Line: 248, Col: 80) - `E501`: line too long (82 > 79 characters)
+- **.\scripts\code_review_formatting.py** (Line: 256, Col: 80) - `E501`: line too long (84 > 79 characters)
+- **.\scripts\code_review_formatting.py** (Line: 263, Col: 80) - `E501`: line too long (83 > 79 characters)
+- **.\scripts\code_review_formatting.py** (Line: 274, Col: 80) - `E501`: line too long (81 > 79 characters)
+- **.\scripts\code_review_formatting.py** (Line: 295, Col: 80) - `E501`: line too long (82 > 79 characters)


### PR DESCRIPTION
## Summary
- add backend support for querying and updating the review folder and keep the page usable when the markdown file is missing
- extend the settings panel with a review folder input, wiring it to the new API and surfacing status feedback in the UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d0187aeb70832bae3fe3af90663afb